### PR TITLE
ci: verify published CLI from a clean directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,10 @@ jobs:
           published_version="$(npm view "$PACKAGE_NAME@$release_version" version)"
           [[ "$published_version" == "$release_version" ]]
           [[ "$attestation_url" == *"/-/npm/v1/attestations/"* ]]
-          public_cli_version="$(npx --yes "$PACKAGE_NAME@$release_version" --version)"
+          public_cli_version="$({
+            cd "$RUNNER_TEMP"
+            npx --yes --registry=https://registry.npmjs.org --package "$PACKAGE_NAME@$release_version" dsh-dingtalk --version
+          })"
           [[ "$public_cli_version" == "$release_version" ]]
           gh release view "v$release_version" >/dev/null
           tag_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/v$release_version" --jq .object.sha)"

--- a/test/release-config.test.mjs
+++ b/test/release-config.test.mjs
@@ -29,7 +29,11 @@ test('组织公开仓库从 0.5.0 开始通过 Trusted Publisher 发布正式版
   assert.match(releaseWorkflow, /dist\.attestations\.url/)
   assert.match(releaseWorkflow, /repository\.url/)
   assert.match(releaseWorkflow, /gh release view/)
-  assert.match(releaseWorkflow, /npx --yes "\$PACKAGE_NAME@\$release_version" --version/)
+  assert.match(releaseWorkflow, /cd "\$RUNNER_TEMP"/)
+  assert.match(
+    releaseWorkflow,
+    /npx --yes --registry=https:\/\/registry\.npmjs\.org --package "\$PACKAGE_NAME@\$release_version" dsh-dingtalk --version/,
+  )
   assert.match(releaseWorkflow, /already belongs to this commit/)
   assert.doesNotMatch(releaseWorkflow, /NODE_AUTH_TOKEN|NPM_BOOTSTRAP_TOKEN|NPM_CONFIG_PROVENANCE: 'false'/)
 })


### PR DESCRIPTION
## Summary

- run the published CLI read-back outside the source checkout
- pin the public npm registry and the exact package/bin invocation
- add a regression assertion for the release workflow

## Verification

- corepack pnpm run ci
- clean-directory public CLI returned 0.5.0