### PR TITLE
fix(setup): keep existing DSH version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 DingTalk connector for [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (DSH). It connects a local DSH Web agent to DingTalk over a Stream connection, without requiring a public inbound endpoint.
 
-> Compatibility: only the latest DSH release is supported. After upgrading DSH, run `doctor` first and report incompatibilities through GitHub Issues.
+> DSH must be installed before setup. Setup keeps an existing DSH version unchanged; after upgrading DSH, run `doctor` first and report incompatibilities through GitHub Issues.
 
 ## Before you start
 
@@ -21,7 +21,7 @@ npx @dingtalk-real-ai/dsh-dingtalk@latest setup
 
 `npx` downloads and runs the CLI for this invocation; it does **not** add `dsh-dingtalk` to your shell's PATH. To reopen setup or run diagnostics later, use the same `npx` form below. If you prefer the shorter `dsh-dingtalk` commands, install the package globally in the optional section.
 
-The guided setup checks or installs the latest DSH, installs this exact plugin version into the `web` profile, creates or configures one or more DingTalk bot accounts, configures optional DWS, image, sender and group access, stores credentials, generates owner-binding codes, and offers to start `dsh web`. New bot accounts default to all senders and all groups.
+The guided setup checks for DSH and installs the latest release only when DSH is absent. It keeps an existing DSH version unchanged, installs this exact plugin version into the `web` profile, creates or configures one or more DingTalk bot accounts, configures optional DWS, image, sender and group access, stores credentials, generates owner-binding codes, and offers to start `dsh web`. New bot accounts default to all senders and all groups.
 
 When DSH Web is ready, send the displayed command to the bot in a direct message:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,7 +4,7 @@
 
 面向 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)（DSH）的钉钉连接器。它通过免公网入口的 Stream 长连接，把本机 DSH Web Agent 接入钉钉。
 
-> 兼容范围：当前只保证兼容最新版 DSH。升级 DSH 后如遇到问题，请先运行 `doctor` 并通过 GitHub Issue 反馈。
+> 使用 setup 前需要已安装 DSH。setup 会保留已安装的 DSH 版本不变；升级 DSH 后如遇到问题，请先运行 `doctor` 并通过 GitHub Issue 反馈。
 
 ## 开始前先了解两件事
 
@@ -22,7 +22,7 @@ npx @dingtalk-real-ai/dsh-dingtalk@latest setup
 引导程序会依次完成：
 
 ```text
-检查或安装最新版 DSH
+检查 DSH；仅在未安装时安装最新版
 → 把当前精确版本插件安装到 web profile
 → 扫码创建钉钉应用，或填写已有凭据
 → 可继续新增其他钉钉机器人

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -93,7 +93,7 @@ function cleanVersion(output: string): string {
   }
 }
 
-async function ensureLatestDsh(ui: SetupUi, runner: CommandRunner): Promise<boolean> {
+async function ensureDshInstalled(ui: SetupUi, runner: CommandRunner): Promise<boolean> {
   let installed = await runWithLoading(ui, runner, '正在检查 DeepSeek Harness…', 'dsh', ['--version'])
   if (installed.code !== 0) {
     if (!(await ui.confirm('installDsh', '未检测到 DeepSeek Harness，是否安装最新版？', true))) return false
@@ -113,38 +113,6 @@ async function ensureLatestDsh(ui: SetupUi, runner: CommandRunner): Promise<bool
     }
   }
 
-  const latest = await runWithLoading(ui, runner, '正在检查 DeepSeek Harness 最新版本…', 'npm', [
-    'view',
-    '@deepseek-ai/dsh',
-    'version',
-    '--json',
-  ])
-  if (latest.code !== 0) {
-    ui.warn('无法连接 NPM 检查 DSH 最新版本；将继续使用当前版本，doctor 会标记为未验证。')
-    return true
-  }
-  const installedVersion = cleanVersion(installed.stdout)
-  const latestVersion = cleanVersion(latest.stdout)
-  if (installedVersion && latestVersion && installedVersion !== latestVersion) {
-    const update = await ui.confirm(
-      'updateDsh',
-      `当前 DSH ${installedVersion}，支持版本为最新的 ${latestVersion}。是否升级？`,
-      true,
-    )
-    if (!update) {
-      ui.warn('当前 DSH 不在第一版支持范围，setup 已停止。')
-      return false
-    }
-    const upgraded = await runWithLoading(ui, runner, '正在升级 DeepSeek Harness…', 'npm', [
-      'install',
-      '--global',
-      `@deepseek-ai/dsh@${latestVersion}`,
-    ])
-    if (upgraded.code !== 0) {
-      ui.warn(`DSH 升级失败：${upgraded.stderr.trim() || 'npm 返回非零状态'}`)
-      return false
-    }
-  }
   return true
 }
 
@@ -432,7 +400,7 @@ export async function runGuidedSetup(options: RunGuidedSetupOptions): Promise<Gu
     ui.warn(`当前 Node.js ${process.versions.node}，要求 ^22.19.0 或 >=24.0.0。`)
     return { code: 2, startWeb: false }
   }
-  if (!(await ensureLatestDsh(ui, runner))) return { code: 2, startWeb: false }
+  if (!(await ensureDshInstalled(ui, runner))) return { code: 2, startWeb: false }
   if (!(await ensurePnpm(ui, runner))) return { code: 2, startWeb: false }
 
   const installed = await runWithLoading(ui, runner, '正在安装 DSH web profile 插件…', 'dsh', [

--- a/test/setup-flow.test.mjs
+++ b/test/setup-flow.test.mjs
@@ -68,6 +68,16 @@ class FakeRunner {
   }
 }
 
+class ExistingOlderDshRunner extends FakeRunner {
+  run(command, args) {
+    if (command === 'dsh' && args[0] === '--version') {
+      this.calls.push([command, ...args])
+      return { code: 0, stdout: '0.1.0-rc.7\n', stderr: '' }
+    }
+    return super.run(command, args)
+  }
+}
+
 class OldPnpmRunner extends FakeRunner {
   pnpmChecks = 0
   run(command, args) {
@@ -149,6 +159,37 @@ test('首次 setup 自动安装精确插件版本并完成完整引导', async (
     },
   ])
   assert.match(ui.messages.join('\n'), /input: \[text, image\]/)
+})
+
+test('已有旧版 DSH 时 setup 不检查 latest 或要求升级', async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-existing-dsh-'))
+  t.after(() => import('node:fs/promises').then((fs) => fs.rm(root, { recursive: true, force: true })))
+  const ui = new FakeUi({
+    credentialMethod: 'manual',
+    clientId: 'ding-app',
+    clientSecret: 'test-only-secret',
+    startWeb: false,
+  })
+  const runner = new ExistingOlderDshRunner()
+
+  const result = await runGuidedSetup({
+    ui,
+    runner,
+    dshHome: path.join(root, '.dsh'),
+    stateDir: path.join(root, '.dsh-dingtalk'),
+    installSpec: '@dingtalk-real-ai/dsh-dingtalk@0.5.0',
+  })
+
+  assert.equal(result.code, 0)
+  assert.equal(
+    runner.calls.some((call) => call[0] === 'npm' && call[1] === 'view'),
+    false,
+  )
+  assert.equal(ui.confirmMessages.has('updateDsh'), false)
+  assert.deepEqual(
+    runner.calls.find((call) => call[0] === 'dsh' && call[1] === 'plugin'),
+    ['dsh', 'plugin', '--profile', 'web', 'add', '@dingtalk-real-ai/dsh-dingtalk@0.5.0'],
+  )
 })
 
 test('重复 setup 可只修改功能配置并保留现有凭据', async (t) => {


### PR DESCRIPTION
## Summary\n\n- remove the installed-DSH latest-version check and automatic DSH upgrade\n- retain installation only when DSH is missing\n- cover an existing older DSH with a setup regression test\n\n## Validation\n\n- node --experimental-test-module-mocks --test test/*.test.mjs\n- tsc -p tsconfig.json --noEmit\n- prettier --check .\n- node scripts/check-secrets.mjs\n- node scripts/check-pack.mjs