### PR TITLE
fix(release): pin supported npm version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,8 @@ jobs:
           node-version: '24.10.0'
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
-      - run: npm install --global npm@latest
+      # npm 12 要求 Node.js 24.15+；发布依赖树已锁定在 npm 11.19.0。
+      - run: npm install --global npm@11.19.0
       - run: pnpm install --frozen-lockfile
       - run: pnpm run ci
       - name: Determine release mode

--- a/test/release-config.test.mjs
+++ b/test/release-config.test.mjs
@@ -25,6 +25,8 @@ test('组织公开仓库从 0.5.0 开始通过 Trusted Publisher 发布正式版
   assert.equal(packageJson.publishConfig.provenance, true)
   assert.match(releaseWorkflow, /id-token: write/)
   assert.match(releaseWorkflow, /node-version: '24\.10\.0'/)
+  assert.match(releaseWorkflow, /npm install --global npm@11\.19\.0/)
+  assert.doesNotMatch(releaseWorkflow, /npm install --global npm@latest/)
   assert.match(ciWorkflow, /pnpm\/action-setup@v6/)
   assert.match(releaseWorkflow, /pnpm\/action-setup@v6/)
   assert.doesNotMatch(`${ciWorkflow}\n${releaseWorkflow}`, /pnpm\/action-setup@v4/)


### PR DESCRIPTION
将 Release workflow 的全局 npm 固定为 11.19.0。此前为了满足 semantic-release 25 固定 Node 24.10+，npm@latest 已升级为需要 Node 24.15+ 的 npm 12，导致发布准备阶段失败。\n\n验证：pnpm run ci