### PR TITLE
fix(setup): support DSH v1 credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ If configuration is incomplete, the plugin logs the exact-version `npx ... setup
 
 ## Credentials and local files
 
-New credentials are stored in `$DSH_HOME/.credentials.yaml` with owner-only permissions. The default account uses `DINGTALK_CLIENT_ID` and `DINGTALK_CLIENT_SECRET`; additional accounts use namespaced references. For example, `support-bot` uses `DINGTALK_ACCOUNT_SUPPORT_BOT_CLIENT_ID` and `DINGTALK_ACCOUNT_SUPPORT_BOT_CLIENT_SECRET`. Setup can migrate an existing default account from `$DSH_HOME/.env` and removes legacy plaintext profile overrides during migration.
+New credentials are stored in `$DSH_HOME/.credentials.yaml` with owner-only permissions. The default account uses `DINGTALK_CLIENT_ID` and `DINGTALK_CLIENT_SECRET`; additional accounts use namespaced references. For example, `support-bot` uses `DINGTALK_ACCOUNT_SUPPORT_BOT_CLIENT_ID` and `DINGTALK_ACCOUNT_SUPPORT_BOT_CLIENT_SECRET`. Setup reads and writes the versioned DSH credential document, updates only these DingTalk references under the shared DSH writer lock, and preserves unrelated references, records, and comments. A legacy flat credential document is migrated to the DSH v1 layout on the next setup write. Setup can also migrate an existing default account from `$DSH_HOME/.env` and removes legacy plaintext profile overrides during migration.
 
 The default account keeps its runtime state under `~/.dsh-dingtalk/`. Additional accounts are isolated under `~/.dsh-dingtalk/accounts/<account-id>/`; owner bindings, session mappings, deduplication and capability state are not shared across accounts. Owner challenges are stored as salted digests, never as plaintext codes. `doctor` reports each account separately.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -129,7 +129,7 @@ dsh web
 
 ## 凭据和本地文件
 
-新凭据写入 `$DSH_HOME/.credentials.yaml`，文件权限仅限当前用户。默认机器人使用 `DINGTALK_CLIENT_ID` 和 `DINGTALK_CLIENT_SECRET`；其他机器人使用带机器人标识的独立引用，例如 `support-bot` 对应 `DINGTALK_ACCOUNT_SUPPORT_BOT_CLIENT_ID` 和 `DINGTALK_ACCOUNT_SUPPORT_BOT_CLIENT_SECRET`。`$DSH_HOME/.env` 中已有的默认机器人凭据可以由 setup 迁移；旧 profile 中的明文凭据覆盖会在迁移时清理。
+新凭据写入 `$DSH_HOME/.credentials.yaml`，文件权限仅限当前用户。默认机器人使用 `DINGTALK_CLIENT_ID` 和 `DINGTALK_CLIENT_SECRET`；其他机器人使用带机器人标识的独立引用，例如 `support-bot` 对应 `DINGTALK_ACCOUNT_SUPPORT_BOT_CLIENT_ID` 和 `DINGTALK_ACCOUNT_SUPPORT_BOT_CLIENT_SECRET`。setup 按 DSH 的版本化凭据文档读写，在共享的 DSH 写锁内只更新这些钉钉引用，并保留无关的引用、记录和注释；旧扁平凭据文档会在下一次 setup 写入时迁移为 DSH v1。`$DSH_HOME/.env` 中已有的默认机器人凭据也可以由 setup 迁移；旧 profile 中的明文凭据覆盖会在迁移时清理。
 
 默认机器人的运行状态继续位于 `~/.dsh-dingtalk/`，其他机器人隔离在 `~/.dsh-dingtalk/accounts/<机器人标识>/`。管理员绑定、会话映射、消息去重和能力状态不会跨机器人共享；管理员绑定口令不会以明文落盘。`doctor` 会按机器人分别展示诊断结果。
 

--- a/scripts/check-pack.mjs
+++ b/scripts/check-pack.mjs
@@ -1,4 +1,7 @@
 import { spawnSync } from 'node:child_process'
+import { chmod, copyFile, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
 import { extractPackReport } from './pack-report.mjs'
 import packageJson from '../package.json' with { type: 'json' }
 
@@ -47,5 +50,46 @@ if (files.some((file) => /(^|\/)(sdk|src|test)(\/|$)/.test(file))) {
   throw new Error('NPM tarball 不得包含 SDK workspace、源码或测试目录')
 }
 if (report.unpackedSize > 10 * 1024 * 1024) throw new Error(`NPM tarball 解包体积过大：${report.unpackedSize}`)
+
+const stagingRoot = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-pack-'))
+try {
+  const stagedPackage = path.join(stagingRoot, 'package')
+  for (const file of files) {
+    const destination = path.join(stagedPackage, file)
+    await mkdir(path.dirname(destination), { recursive: true })
+    await copyFile(path.resolve(file), destination)
+  }
+  await symlink(
+    path.resolve('node_modules'),
+    path.join(stagedPackage, 'node_modules'),
+    process.platform === 'win32' ? 'junction' : 'dir',
+  )
+
+  const dshHome = path.join(stagingRoot, '.dsh')
+  const profile = path.join(dshHome, 'profiles', 'web')
+  await mkdir(profile, { recursive: true })
+  const credentialsFile = path.join(dshHome, '.credentials.yaml')
+  await writeFile(
+    credentialsFile,
+    'version: 1\nrefs:\n  DINGTALK_CLIENT_ID: packed-app\n  DINGTALK_CLIENT_SECRET: packed-secret\n',
+    { mode: 0o600 },
+  )
+  if (process.platform !== 'win32') await chmod(credentialsFile, 0o600)
+  await writeFile(
+    path.join(profile, 'cordis.patch.yml'),
+    '- id: dingtalk-channel\n  config:\n    ownerStaffId: packed-owner\n',
+  )
+  const doctor = spawnSync(process.execPath, [path.join(stagedPackage, 'lib', 'bin.js'), 'doctor', '--offline'], {
+    encoding: 'utf8',
+    env: { ...process.env, HOME: stagingRoot, DSH_HOME: dshHome },
+  })
+  if (doctor.status !== 0 || !/应用凭据：已配置/.test(doctor.stdout)) {
+    throw new Error(
+      doctor.stderr || doctor.stdout || doctor.error?.message || 'NPM tarball 中的 doctor 无法读取 DSH v1 凭据',
+    )
+  }
+} finally {
+  await rm(stagingRoot, { recursive: true, force: true })
+}
 
 console.log(`NPM tarball 校验通过：${files.length} files, ${report.unpackedSize} bytes unpacked`)

--- a/src/setup-state.ts
+++ b/src/setup-state.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto'
-import { chmod, mkdir, readFile, rename, stat, writeFile } from 'node:fs/promises'
+import { chmod, lstat, mkdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises'
 import path from 'node:path'
-import { parse, stringify } from 'yaml'
+import { isMap, parse, parseDocument, stringify, YAMLMap } from 'yaml'
 import { accountCredentialRefs, assertAccountId, DEFAULT_ACCOUNT_ID, type AccountCredentialRefs } from './accounts.js'
 import type { DingTalkAppCredentials } from './credentials.js'
 
@@ -84,17 +84,160 @@ async function assertPrivateFile(file: string): Promise<void> {
   }
 }
 
-function parseCredentialDocument(source: string | undefined, file: string): Record<string, string> {
-  if (source === undefined || source.trim() === '') return {}
-  const value = parse(source, { uniqueKeys: true })
-  if (value === null) return {}
-  if (typeof value !== 'object' || Array.isArray(value)) throw new Error(`凭据文件 ${file} 必须是 YAML mapping`)
+interface CredentialDocument {
+  refs: Record<string, string>
+  setRef(key: string, value: string): void
+  serialize(): string
+}
+
+function validateCredentialRefs(value: unknown, file: string): Record<string, string> {
+  if (value === undefined || value === null) return {}
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`凭据文件 ${file} 的 refs 必须是 YAML mapping`)
+  }
   for (const [key, entry] of Object.entries(value)) {
     if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key) || typeof entry !== 'string' || entry.length === 0) {
       throw new Error(`凭据文件 ${file} 包含无效条目 ${key}`)
     }
   }
   return value as Record<string, string>
+}
+
+function assertCredentialRecordFields(
+  key: string,
+  fields: Record<string, unknown>,
+  allowed: readonly string[],
+  file: string,
+): void {
+  for (const field of Object.keys(fields)) {
+    if (!allowed.includes(field)) {
+      throw new Error(`凭据文件 ${file} 的 record ${key} 包含未知字段 ${field}`)
+    }
+  }
+}
+
+function assertJsonCredentialValue(value: unknown, key: string, file: string, seen = new Set<object>()): void {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return
+  if (typeof value === 'number') {
+    if (Number.isFinite(value)) return
+    throw new Error(`凭据文件 ${file} 的 record ${key} payload 包含非有限数字`)
+  }
+  if (typeof value === 'object') {
+    if (seen.has(value)) throw new Error(`凭据文件 ${file} 的 record ${key} payload 包含循环引用`)
+    if (Object.getPrototypeOf(value) === Object.prototype || Array.isArray(value)) {
+      seen.add(value)
+      for (const nested of Object.values(value)) assertJsonCredentialValue(nested, key, file, seen)
+      seen.delete(value)
+      return
+    }
+  }
+  throw new Error(`凭据文件 ${file} 的 record ${key} payload 不是 JSON 可表示的值`)
+}
+
+function validateCredentialRecords(value: unknown, file: string): void {
+  if (value === undefined || value === null) return
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`凭据文件 ${file} 的 records 必须是 YAML mapping`)
+  }
+  for (const [key, record] of Object.entries(value)) {
+    if (!/^[a-z][a-z0-9-]*\/[a-z][a-z0-9-]*$/.test(key)) {
+      throw new Error(`凭据文件 ${file} 包含无效的 record key ${key}`)
+    }
+    if (typeof record !== 'object' || record === null || Array.isArray(record)) {
+      throw new Error(`凭据文件 ${file} 的 record ${key} 必须是 YAML mapping`)
+    }
+    const fields = record as Record<string, unknown>
+    if (fields.kind === 'api-key') {
+      assertCredentialRecordFields(key, fields, ['kind', 'key', 'env'], file)
+      if (fields.key !== undefined && (typeof fields.key !== 'string' || fields.key.length === 0)) {
+        throw new Error(`凭据文件 ${file} 的 record ${key} 包含无效的 api-key key`)
+      }
+      if (fields.env !== undefined) {
+        if (typeof fields.env !== 'object' || fields.env === null || Array.isArray(fields.env)) {
+          throw new Error(`凭据文件 ${file} 的 record ${key} env 必须是 YAML mapping`)
+        }
+        for (const [name, entry] of Object.entries(fields.env)) {
+          if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name) || typeof entry !== 'string' || entry.length === 0) {
+            throw new Error(`凭据文件 ${file} 的 record ${key} 包含无效 env 条目 ${name}`)
+          }
+        }
+      }
+      continue
+    }
+    if (fields.kind === 'grant') {
+      assertCredentialRecordFields(key, fields, ['kind', 'payload'], file)
+      if (!('payload' in fields)) throw new Error(`凭据文件 ${file} 的 record ${key} 缺少 payload`)
+      assertJsonCredentialValue(fields.payload, key, file)
+      continue
+    }
+    if (fields.kind === undefined) throw new Error(`凭据文件 ${file} 的 record ${key} 缺少 kind`)
+    throw new Error(`凭据文件 ${file} 的 record ${key} 使用未知 kind`)
+  }
+}
+
+function parseCredentialDocument(source: string | undefined, file: string): CredentialDocument {
+  let document = parseDocument(source ?? '', { uniqueKeys: true })
+  if (document.errors.length) {
+    throw new Error(`凭据文件 ${file} 不是有效的 YAML 文档`)
+  }
+
+  let refsNode: YAMLMap
+  let refs: Record<string, string>
+  if (document.contents === null) {
+    const commentBefore = document.commentBefore
+    const comment = document.comment
+    document = parseDocument('version: 1\nrefs: {}\n', { uniqueKeys: true })
+    document.commentBefore = commentBefore
+    document.comment = comment
+    const createdRefs = document.get('refs', true)
+    if (!isMap(createdRefs)) throw new Error(`无法初始化凭据文件 ${file}`)
+    refsNode = createdRefs
+    refs = {}
+  } else {
+    if (!isMap(document.contents)) throw new Error(`凭据文件 ${file} 必须是 YAML mapping`)
+    const value = document.toJS() as Record<string, unknown>
+    if ('version' in value) {
+      if (value.version !== 1) throw new Error(`凭据文件 ${file} 使用不受支持的版本 ${String(value.version)}`)
+      for (const key of Object.keys(value)) {
+        if (key !== 'version' && key !== 'refs' && key !== 'records') {
+          throw new Error(`凭据文件 ${file} 包含未知的顶层字段 ${key}`)
+        }
+      }
+      validateCredentialRecords(value.records, file)
+      refs = validateCredentialRefs(value.refs, file)
+      const currentRefs = document.get('refs', true)
+      if (value.refs === undefined || value.refs === null) {
+        const createdMap = new YAMLMap()
+        const currentComment = (currentRefs as { comment?: unknown } | undefined)?.comment
+        if (typeof currentComment === 'string') createdMap.commentBefore = currentComment
+        document.set('refs', createdMap)
+        const createdRefs = document.get('refs', true)
+        if (!isMap(createdRefs)) throw new Error(`无法初始化凭据文件 ${file} 的 refs`)
+        refsNode = createdRefs
+      } else {
+        if (!isMap(currentRefs)) throw new Error(`凭据文件 ${file} 的 refs 必须是 YAML mapping`)
+        refsNode = currentRefs
+      }
+    } else {
+      refs = validateCredentialRefs(value, file)
+      const legacyRefs = document.contents
+      document = parseDocument('version: 1\nrefs: {}\n', { uniqueKeys: true })
+      document.set('refs', legacyRefs)
+      const migratedRefs = document.get('refs', true)
+      if (!isMap(migratedRefs)) throw new Error(`无法迁移凭据文件 ${file}`)
+      refsNode = migratedRefs
+    }
+  }
+
+  return {
+    refs,
+    setRef(key, value) {
+      refsNode.set(key, value)
+    },
+    serialize() {
+      return document.toString({ lineWidth: 0 })
+    },
+  }
 }
 
 async function atomicPrivateWrite(file: string, content: string): Promise<void> {
@@ -104,6 +247,42 @@ async function atomicPrivateWrite(file: string, content: string): Promise<void> 
   await chmod(temporary, 0o600)
   await rename(temporary, file)
   await chmod(file, 0o600)
+}
+
+async function isCredentialLockContention(error: unknown, lockFile: string): Promise<boolean> {
+  const code = (error as NodeJS.ErrnoException | null)?.code
+  if (code === 'EEXIST') return true
+  if (code !== 'EPERM') return false
+  try {
+    await lstat(lockFile)
+    return true
+  } catch {
+    return false
+  }
+}
+
+// 与 DSH dsh-atomic-write 共用 `<凭据文件>.lock` 协议，确保双方的读改写不会互相覆盖。
+async function withCredentialFileLock<T>(file: string, operation: () => Promise<T>): Promise<T> {
+  await mkdir(path.dirname(file), { recursive: true, mode: 0o700 })
+  const lockFile = `${file}.lock`
+  const deadline = Date.now() + 30_000
+  let delay = 20
+  for (;;) {
+    try {
+      await writeFile(lockFile, `${process.pid}\n`, { mode: 0o600, flag: 'wx' })
+      break
+    } catch (error) {
+      if (!(await isCredentialLockContention(error, lockFile))) throw error
+    }
+    if (Date.now() >= deadline) throw new Error(`等待凭据文件写锁超时：${lockFile}`)
+    await new Promise((resolve) => setTimeout(resolve, delay))
+    delay = Math.min(delay * 2, 200)
+  }
+  try {
+    return await operation()
+  } finally {
+    await rm(lockFile, { force: true })
+  }
 }
 
 function parseLegacyEnv(
@@ -135,9 +314,9 @@ export async function loadDingTalkAccountCredentials(
   const source = await readOptional(file)
   if (source !== undefined) {
     await assertPrivateFile(file)
-    const values = parseCredentialDocument(source, file)
-    const clientId = values[credentialRefs.clientIdRef] ?? ''
-    const clientSecret = values[credentialRefs.clientSecretRef] ?? ''
+    const document = parseCredentialDocument(source, file)
+    const clientId = document.refs[credentialRefs.clientIdRef] ?? ''
+    const clientSecret = document.refs[credentialRefs.clientSecretRef] ?? ''
     if (clientId && clientSecret) return { clientId, clientSecret, source: 'credentials' }
   }
 
@@ -162,13 +341,15 @@ export async function saveDingTalkAccountCredentials(
     throw new Error('Client ID 和 Client Secret 不能为空')
   const refs = accountCredentialRefs(accountId)
   const file = credentialsPath(dshHome)
-  const existing = await readOptional(file)
-  if (existing !== undefined) await assertPrivateFile(file)
-  const values = parseCredentialDocument(existing, file)
-  values[refs.clientIdRef] = credentials.clientId.trim()
-  values[refs.clientSecretRef] = credentials.clientSecret.trim()
-  await atomicPrivateWrite(file, stringify(values, { lineWidth: 0 }))
-  return file
+  return withCredentialFileLock(file, async () => {
+    const existing = await readOptional(file)
+    if (existing !== undefined) await assertPrivateFile(file)
+    const document = parseCredentialDocument(existing, file)
+    document.setRef(refs.clientIdRef, credentials.clientId.trim())
+    document.setRef(refs.clientSecretRef, credentials.clientSecret.trim())
+    await atomicPrivateWrite(file, document.serialize())
+    return file
+  })
 }
 
 function profileEntries(source: string | undefined, file: string): Array<Record<string, unknown>> {

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -4,6 +4,7 @@ import { spawnSync } from 'node:child_process'
 import os from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
+import { parse } from 'yaml'
 
 test('公开帮助只推荐正式 latest 安装渠道', () => {
   const result = spawnSync(process.execPath, ['lib/bin.js', '--help'], {
@@ -61,6 +62,13 @@ test('公开 setup CLI 在一个进程内完成插件安装和配置', async (t)
   assert.match(await readFile(log, 'utf8'), /dsh plugin --profile web add/)
   assert.match(result.stdout, /检测到 dsh web 正在运行/)
   assert.doesNotMatch(await readFile(log, 'utf8'), /dsh web/)
+  assert.deepEqual(parse(await readFile(path.join(root, '.dsh', '.credentials.yaml'), 'utf8')), {
+    version: 1,
+    refs: {
+      DINGTALK_CLIENT_ID: 'ding-cli',
+      DINGTALK_CLIENT_SECRET: 'secret-cli',
+    },
+  })
 })
 
 test('doctor 识别 web profile 中显式配置的管理员', async (t) => {
@@ -82,6 +90,35 @@ test('doctor 识别 web profile 中显式配置的管理员', async (t) => {
 
   assert.equal(result.status, 1)
   assert.match(result.stdout, /✅ 唯一管理员：已完成绑定或显式配置/)
+})
+
+test('doctor 读取 DSH v1 凭据文件', async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-cli-v1-doctor-'))
+  t.after(() => import('node:fs/promises').then((fs) => fs.rm(root, { recursive: true, force: true })))
+  const dshHome = path.join(root, '.dsh')
+  const profile = path.join(dshHome, 'profiles', 'web')
+  await import('node:fs/promises').then((fs) => fs.mkdir(profile, { recursive: true }))
+  await writeFile(
+    path.join(dshHome, '.credentials.yaml'),
+    ['version: 1', 'refs:', '  DINGTALK_CLIENT_ID: default-app', '  DINGTALK_CLIENT_SECRET: default-secret', ''].join(
+      '\n',
+    ),
+    { mode: 0o600 },
+  )
+  await writeFile(
+    path.join(profile, 'cordis.patch.yml'),
+    '- id: dingtalk-channel\n  config:\n    ownerStaffId: configured-owner\n',
+  )
+
+  const result = spawnSync(process.execPath, ['lib/bin.js', 'doctor', '--offline'], {
+    cwd: path.resolve('.'),
+    encoding: 'utf8',
+    env: { ...process.env, HOME: root, DSH_HOME: dshHome },
+  })
+
+  assert.equal(result.status, 0, result.stderr || result.stdout)
+  assert.match(result.stdout, /⚠️ 应用凭据：已配置，但本次未执行联网验证/)
+  assert.doesNotMatch(result.stderr, /无效条目 version/)
 })
 
 test('doctor 分账号展示多条 Stream 与凭据诊断', async (t) => {

--- a/test/setup-flow.test.mjs
+++ b/test/setup-flow.test.mjs
@@ -133,8 +133,11 @@ test('首次 setup 自动安装精确插件版本并完成完整引导', async (
   assert.doesNotMatch(ui.messages.join('\n'), /super-secret/)
   assert.doesNotMatch(ui.prompted.join(','), /interactionCardTemplateId/)
   assert.deepEqual(parse(await readFile(path.join(dshHome, '.credentials.yaml'), 'utf8')), {
-    DINGTALK_CLIENT_ID: 'ding-app',
-    DINGTALK_CLIENT_SECRET: 'super-secret',
+    version: 1,
+    refs: {
+      DINGTALK_CLIENT_ID: 'ding-app',
+      DINGTALK_CLIENT_SECRET: 'super-secret',
+    },
   })
   assert.deepEqual(parse(await readFile(path.join(dshHome, 'profiles', 'web', 'cordis.patch.yml'), 'utf8')), [
     {
@@ -225,8 +228,11 @@ test('重复 setup 可只修改功能配置并保留现有凭据', async (t) => 
   assert.equal(result.code, 0)
   assert.match(ui.confirmMessages.get('startWeb'), /\/bind/)
   assert.deepEqual(parse(await readFile(path.join(dshHome, '.credentials.yaml'), 'utf8')), {
-    DINGTALK_CLIENT_ID: 'existing-id',
-    DINGTALK_CLIENT_SECRET: 'existing-secret',
+    version: 1,
+    refs: {
+      DINGTALK_CLIENT_ID: 'existing-id',
+      DINGTALK_CLIENT_SECRET: 'existing-secret',
+    },
   })
   assert.match(ui.messages.join('\n'), /机器人 default 的一次性管理员绑定口令/)
   assert.deepEqual(parse(await readFile(path.join(dshHome, 'profiles', 'web', 'cordis.patch.yml'), 'utf8')), [
@@ -306,10 +312,13 @@ test('重复 setup 可新增第二个机器人账号且不覆盖默认账号', a
 
   assert.equal(result.code, 0)
   assert.deepEqual(parse(await readFile(path.join(dshHome, '.credentials.yaml'), 'utf8')), {
-    DINGTALK_CLIENT_ID: 'default-id',
-    DINGTALK_CLIENT_SECRET: 'default-secret',
-    DINGTALK_ACCOUNT_SUPPORT_BOT_CLIENT_ID: 'support-id',
-    DINGTALK_ACCOUNT_SUPPORT_BOT_CLIENT_SECRET: 'support-secret',
+    version: 1,
+    refs: {
+      DINGTALK_CLIENT_ID: 'default-id',
+      DINGTALK_CLIENT_SECRET: 'default-secret',
+      DINGTALK_ACCOUNT_SUPPORT_BOT_CLIENT_ID: 'support-id',
+      DINGTALK_ACCOUNT_SUPPORT_BOT_CLIENT_SECRET: 'support-secret',
+    },
   })
   const profile = parse(await readFile(path.join(dshHome, 'profiles', 'web', 'cordis.patch.yml'), 'utf8'))
   assert.deepEqual(

--- a/test/setup-state.test.mjs
+++ b/test/setup-state.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { chmod, mkdtemp, readFile, stat, writeFile } from 'node:fs/promises'
+import { chmod, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
@@ -16,7 +16,7 @@ import {
   updateWebProfileConfig,
 } from '../lib/setup-state.js'
 
-test('setup 将钉钉凭据写入 DSH 凭据存储并保留其他键', async (t) => {
+test('setup 将旧扁平凭据迁移为 DSH v1 并保留其他键', async (t) => {
   const dshHome = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-credentials-'))
   t.after(() => import('node:fs/promises').then((fs) => fs.rm(dshHome, { recursive: true, force: true })))
   const file = path.join(dshHome, '.credentials.yaml')
@@ -25,9 +25,12 @@ test('setup 将钉钉凭据写入 DSH 凭据存储并保留其他键', async (t)
   await saveDingTalkCredentials(dshHome, { clientId: 'ding-app', clientSecret: 'super-secret' })
 
   assert.deepEqual(parse(await readFile(file, 'utf8')), {
-    OPENAI_API_KEY: 'keep-me',
-    DINGTALK_CLIENT_ID: 'ding-app',
-    DINGTALK_CLIENT_SECRET: 'super-secret',
+    version: 1,
+    refs: {
+      OPENAI_API_KEY: 'keep-me',
+      DINGTALK_CLIENT_ID: 'ding-app',
+      DINGTALK_CLIENT_SECRET: 'super-secret',
+    },
   })
   if (process.platform !== 'win32') assert.equal((await stat(file)).mode & 0o777, 0o600)
   assert.deepEqual(await loadDingTalkCredentials(dshHome), {
@@ -35,6 +38,154 @@ test('setup 将钉钉凭据写入 DSH 凭据存储并保留其他键', async (t)
     clientSecret: 'super-secret',
     source: 'credentials',
   })
+})
+
+test('setup 读写 DSH v1 凭据并保留其他引用、记录与注释', async (t) => {
+  const dshHome = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-v1-credentials-'))
+  t.after(() => import('node:fs/promises').then((fs) => fs.rm(dshHome, { recursive: true, force: true })))
+  const file = path.join(dshHome, '.credentials.yaml')
+  await writeFile(
+    file,
+    [
+      'version: 1',
+      'refs:',
+      '  OPENAI_API_KEY: keep-me # 保留无关引用',
+      'records:',
+      '  llm-pi-ai/test-route:',
+      '    kind: api-key',
+      '    env:',
+      '      AWS_PROFILE: test-profile # 保留无关记录',
+      '',
+    ].join('\n'),
+    { mode: 0o600 },
+  )
+
+  await saveDingTalkCredentials(dshHome, { clientId: 'ding-app', clientSecret: 'super-secret' })
+
+  const saved = await readFile(file, 'utf8')
+  assert.deepEqual(parse(saved), {
+    version: 1,
+    refs: {
+      OPENAI_API_KEY: 'keep-me',
+      DINGTALK_CLIENT_ID: 'ding-app',
+      DINGTALK_CLIENT_SECRET: 'super-secret',
+    },
+    records: {
+      'llm-pi-ai/test-route': {
+        kind: 'api-key',
+        env: { AWS_PROFILE: 'test-profile' },
+      },
+    },
+  })
+  assert.match(saved, /# 保留无关引用/)
+  assert.match(saved, /# 保留无关记录/)
+  assert.deepEqual(await loadDingTalkCredentials(dshHome), {
+    clientId: 'ding-app',
+    clientSecret: 'super-secret',
+    source: 'credentials',
+  })
+})
+
+test('setup 接受 DSH v1 的空章节并保留空 records', async (t) => {
+  const dshHome = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-null-credentials-'))
+  t.after(() => import('node:fs/promises').then((fs) => fs.rm(dshHome, { recursive: true, force: true })))
+  const file = path.join(dshHome, '.credentials.yaml')
+  await writeFile(file, 'version: 1\nrefs: # 用户说明\nrecords:\n', { mode: 0o600 })
+
+  await saveDingTalkCredentials(dshHome, { clientId: 'ding-app', clientSecret: 'super-secret' })
+
+  const saved = await readFile(file, 'utf8')
+  assert.deepEqual(parse(saved), {
+    version: 1,
+    refs: {
+      DINGTALK_CLIENT_ID: 'ding-app',
+      DINGTALK_CLIENT_SECRET: 'super-secret',
+    },
+    records: null,
+  })
+  assert.match(saved, /refs:\n  # 用户说明\n/)
+})
+
+test('setup 从仅含注释的凭据文件初始化时保留文档注释', async (t) => {
+  const dshHome = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-comment-credentials-'))
+  t.after(() => import('node:fs/promises').then((fs) => fs.rm(dshHome, { recursive: true, force: true })))
+  const file = path.join(dshHome, '.credentials.yaml')
+  await writeFile(file, '# 由用户管理的凭据\n', { mode: 0o600 })
+
+  await saveDingTalkCredentials(dshHome, { clientId: 'ding-app', clientSecret: 'super-secret' })
+
+  assert.match(await readFile(file, 'utf8'), /^# 由用户管理的凭据\n/)
+})
+
+test('setup 遇到 DSH 无法读取的 record 时安全退出且不改写文件', async (t) => {
+  const dshHome = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-invalid-record-'))
+  t.after(() => import('node:fs/promises').then((fs) => fs.rm(dshHome, { recursive: true, force: true })))
+  const file = path.join(dshHome, '.credentials.yaml')
+  const original = [
+    'version: 1',
+    'refs:',
+    '  OPENAI_API_KEY: keep-me',
+    'records:',
+    '  llm-pi-ai/test-route:',
+    '    kind: api-key',
+    '    typo: must-not-be-dropped',
+    '',
+  ].join('\n')
+  await writeFile(file, original, { mode: 0o600 })
+
+  await assert.rejects(
+    () => saveDingTalkCredentials(dshHome, { clientId: 'ding-app', clientSecret: 'super-secret' }),
+    /record llm-pi-ai\/test-route 包含未知字段 typo/,
+  )
+
+  assert.equal(await readFile(file, 'utf8'), original)
+  await assert.rejects(() => stat(`${file}.lock`), { code: 'ENOENT' })
+})
+
+test('setup 与 DSH 并发写入时等待共享锁并合并最新引用', async (t) => {
+  const dshHome = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-locked-credentials-'))
+  t.after(() => import('node:fs/promises').then((fs) => fs.rm(dshHome, { recursive: true, force: true })))
+  const file = path.join(dshHome, '.credentials.yaml')
+  const lock = `${file}.lock`
+  await writeFile(file, 'version: 1\nrefs:\n  OPENAI_API_KEY: before\n', { mode: 0o600 })
+  await writeFile(lock, 'test-writer\n', { mode: 0o600 })
+
+  const saving = saveDingTalkCredentials(dshHome, { clientId: 'ding-app', clientSecret: 'super-secret' })
+  const finishedBeforeUnlock = await Promise.race([
+    saving.then(() => true),
+    new Promise((resolve) => setTimeout(() => resolve(false), 50)),
+  ])
+  assert.equal(finishedBeforeUnlock, false)
+
+  await writeFile(file, 'version: 1\nrefs:\n  OPENAI_API_KEY: after\n  CONCURRENT_KEY: keep-me\n', { mode: 0o600 })
+  await rm(lock)
+  await saving
+
+  assert.deepEqual(parse(await readFile(file, 'utf8')), {
+    version: 1,
+    refs: {
+      OPENAI_API_KEY: 'after',
+      CONCURRENT_KEY: 'keep-me',
+      DINGTALK_CLIENT_ID: 'ding-app',
+      DINGTALK_CLIENT_SECRET: 'super-secret',
+    },
+  })
+})
+
+test('setup 遇到未知 DSH 凭据版本时安全退出且不改写文件', async (t) => {
+  const dshHome = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-future-credentials-'))
+  t.after(() => import('node:fs/promises').then((fs) => fs.rm(dshHome, { recursive: true, force: true })))
+  const file = path.join(dshHome, '.credentials.yaml')
+  const original = 'version: 2\nrefs:\n  OPENAI_API_KEY: keep-me\n'
+  await writeFile(file, original, { mode: 0o600 })
+
+  await assert.rejects(
+    () => saveDingTalkCredentials(dshHome, { clientId: 'ding-app', clientSecret: 'super-secret' }),
+    /使用不受支持的版本 2/,
+  )
+
+  assert.equal(await readFile(file, 'utf8'), original)
+  await assert.rejects(() => stat(`${file}.lock`), { code: 'ENOENT' })
 })
 
 test('setup 拒绝读取权限过宽的凭据文件', async (t) => {
@@ -101,10 +252,13 @@ test('多个钉钉账号使用独立凭据引用且不会覆盖默认账号', as
   assert.equal((await loadDingTalkAccountCredentials(dshHome, 'default'))?.clientId, 'default-app')
   assert.equal((await loadDingTalkAccountCredentials(dshHome, 'support-bot'))?.clientId, 'support-app')
   assert.deepEqual(parse(await readFile(path.join(dshHome, '.credentials.yaml'), 'utf8')), {
-    DINGTALK_CLIENT_ID: 'default-app',
-    DINGTALK_CLIENT_SECRET: 'default-secret',
-    DINGTALK_ACCOUNT_SUPPORT_BOT_CLIENT_ID: 'support-app',
-    DINGTALK_ACCOUNT_SUPPORT_BOT_CLIENT_SECRET: 'support-secret',
+    version: 1,
+    refs: {
+      DINGTALK_CLIENT_ID: 'default-app',
+      DINGTALK_CLIENT_SECRET: 'default-secret',
+      DINGTALK_ACCOUNT_SUPPORT_BOT_CLIENT_ID: 'support-app',
+      DINGTALK_ACCOUNT_SUPPORT_BOT_CLIENT_SECRET: 'support-secret',
+    },
   })
 })
 


### PR DESCRIPTION
## 问题

DSH 0.1.1-rc.2 使用带 `version: 1`、`refs` 和可选 `records` 的凭据文档。连接器此前只接受旧的扁平键值结构，导致已有 DSH 凭据文件时 `setup` / `doctor` 失败；保存路径还有整体重写共享文件的风险。

## 修复

- 读取和更新 DSH v1 凭据文档，只增改本连接器拥有的引用
- 保留其他 `refs`、`records` 与 YAML 注释；旧扁平结构在保存时迁移为 v1
- 与 DSH 共用 `<credentials>.lock` 协议，在锁内重读并原子写入，避免并发覆盖
- 对未来版本、未知顶层字段和无效 records 采取 fail-closed，不改写原文件
- 更新中英文凭据共存说明

## 验证

- `pnpm run ci`
- 97/97 tests passed
- 覆盖公开 `setup` / `doctor` CLI、并发写入、旧格式迁移、空章节、records 校验、注释保持及 NPM 发布文件集中的 v1 doctor

## 已知限制

无。

Fixes #2
