### PR TITLE
test(approval): make timeout runtime deterministic

### DIFF
--- a/test/approval-runtime.test.mjs
+++ b/test/approval-runtime.test.mjs
@@ -169,6 +169,7 @@ test('公开 apply 运行时允许管理员通过私聊或同群一次性文字�
   await robotListener(delivery('start', '开始'))
   await waitUntil(() => typeof listeners.get('approval/request') === 'function' && followupCount === 1)
   const approve = listeners.get('approval/request')
+  t.mock.timers.enable({ apis: ['setTimeout'] })
   let fallbackCalls = 0
   const outcome = approve(
     {
@@ -206,6 +207,9 @@ test('公开 apply 运行时允许管理员通过私聊或同群一次性文字�
   await robotListener(delivery('owner-confirm', `确认 ${code}`))
   assert.equal(await outcome, 'allowed-once')
 
+  const timeoutApprovalMessageCount = requests.filter((request) =>
+    request.body?.markdown?.text?.includes('审批敏感操作'),
+  ).length
   const timedOut = approve(
     {
       agent,
@@ -214,8 +218,18 @@ test('公开 apply 运行时允许管理员通过私聊或同群一次性文字�
     },
     async () => 'unavailable',
   )
+  await waitUntil(
+    () =>
+      requests.filter((request) => request.body?.markdown?.text?.includes('审批敏感操作')).length ===
+      timeoutApprovalMessageCount + 1,
+  )
+  t.mock.timers.tick(config.approvalTimeoutMs)
   assert.equal(await timedOut, 'unavailable')
-  assert.match(requests.at(-1).body.markdown.text, /审批已超时/)
+  await waitUntil(() => requests.some((request) => /审批已超时/.test(request.body?.markdown?.text ?? '')))
+  assert.match(
+    requests.findLast((request) => /审批已超时/.test(request.body?.markdown?.text ?? '')).body.markdown.text,
+    /审批已超时/,
+  )
 
   const approvalMessageCount = requests.filter((request) =>
     request.body?.markdown?.text?.includes('审批敏感操作'),


### PR DESCRIPTION
## 背景

main CI [32834748524](https://github.com/DingTalk-Real-AI/dsh-dingtalk/actions/runs/32834748524) 的 Ubuntu job 在 `approval-runtime.test.mjs:204` 失败：80ms 真实审批计时器在两次无权限消息断言之前触发，属于测试调度竞态。生产审批仍按总截止时间 fail-closed，行为正确。

## 修改

- 仅在该运行时测试里冻结 `setTimeout`
- 等第二次审批提示确认送达后显式推进 80ms
- 等异步超时通知写入后再断言
- 不修改生产代码或审批安全语义

## 验证

- Node.js 22.22.3 定向重复：50/50 通过
- `pnpm 11.7.0 run ci`：162/162 通过
- secret scan、Prettier、typecheck、NPM tarball 校验通过
- 独立只读评审：无阻塞