### PR TITLE
fix(setup): make install failures diagnosable

### DIFF
--- a/src/console-ui.ts
+++ b/src/console-ui.ts
@@ -32,9 +32,9 @@ export class ConsoleSetupUi implements SetupUi {
     console.log(`✅ ${message}`)
   }
 
-  loading(message: string): () => void {
+  loading(message: string): (succeeded: boolean, completedMessage: string) => void {
     console.log(`⏳ ${message}`)
-    return () => console.log(`✅ ${message}`)
+    return (succeeded, completedMessage) => console.log(`${succeeded ? '✅' : '❌'} ${completedMessage}`)
   }
 
   async confirm(_id: string, message: string, initial: boolean): Promise<boolean> {

--- a/src/install-diagnostics.ts
+++ b/src/install-diagnostics.ts
@@ -1,0 +1,187 @@
+import { randomUUID } from 'node:crypto'
+import { mkdir, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import type { CommandResult } from './setup.js'
+
+export type InstallStage = 'dsh_install' | 'pnpm_install' | 'plugin_install'
+
+export interface InstallDiagnostic {
+  stage: InstallStage
+  errorCode?: string
+  primaryMessage: string
+  packageSpec?: string
+  registry?: string
+  dependency?: string
+  suggestedAction: string
+  logPath?: string
+}
+
+interface DiagnoseCommandFailureOptions {
+  stage: InstallStage
+  command: string
+  args: string[]
+  result: CommandResult
+  stateDir: string
+}
+
+const ANSI_ESCAPE = /\u001B(?:\[[0-?]*[ -/]*[@-~]|\][^\u0007]*(?:\u0007|\u001B\\))/gu
+const KNOWN_ERROR_CODES = [
+  'ERR_PNPM_NO_MATCHING_VERSION',
+  'ETARGET',
+  'E401',
+  'E403',
+  'EACCES',
+  'EPERM',
+  'ENOTFOUND',
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'ENETUNREACH',
+  'EAI_AGAIN',
+  'ENOSPC',
+] as const
+
+function cleanOutput(value: string): string {
+  return value.replace(ANSI_ESCAPE, '').replaceAll('\r', '')
+}
+
+function combinedOutput(result: CommandResult): string {
+  return [result.stdout, result.stderr].filter(Boolean).map(cleanOutput).join('\n').trim()
+}
+
+function extractErrorCode(output: string): string | undefined {
+  const bracketed = output.match(/\[((?:ERR_[A-Z0-9_]+|E[A-Z0-9_]+))\]/u)?.[1]
+  if (bracketed) return bracketed
+  const npmCode = output.match(/npm\s+(?:error|ERR!)\s+code\s+([A-Z][A-Z0-9_]*)/iu)?.[1]
+  if (npmCode) return npmCode.toUpperCase()
+  return KNOWN_ERROR_CODES.find((code) => new RegExp(`(?:^|\\s)${code}(?:\\s|:|$)`, 'mu').test(output))
+}
+
+function extractPackageSpec(output: string): string | undefined {
+  const value = output.match(/No matching version found for\s+([^\s]+?)(?:[.。]?)(?:\n|$)/iu)?.[1]
+  return value?.replace(/[.。]$/u, '')
+}
+
+function safeRegistry(value: string): string | undefined {
+  try {
+    const parsed = new URL(value.replace(/[>,.;。]+$/u, ''))
+    parsed.username = ''
+    parsed.password = ''
+    parsed.search = ''
+    parsed.hash = ''
+    return parsed.toString()
+  } catch {
+    return undefined
+  }
+}
+
+function extractRegistry(output: string): string | undefined {
+  const value = output.match(/while fetching it from\s+(https?:\/\/\S+)/iu)?.[1]
+  return value ? safeRegistry(value) : undefined
+}
+
+function extractDependency(output: string): string | undefined {
+  return output
+    .match(/This error happened while installing the dependencies of\s+([^\s]+)/iu)?.[1]
+    ?.replace(/[.。]$/u, '')
+}
+
+function redactSensitive(value: string): string {
+  return value
+    .replace(/https?:\/\/[^\s<>"']+/gu, (candidate) => safeRegistry(candidate) ?? '[REDACTED_URL]')
+    .replace(/((?:_authToken|authToken|token|password|secret)\s*[:=]\s*)[^\s]+/giu, '$1[REDACTED]')
+    .replace(/(Bearer\s+)[^\s]+/giu, '$1[REDACTED]')
+    .replace(/\bnpm_[A-Za-z0-9_-]+\b/gu, '[REDACTED]')
+}
+
+function extractPrimaryMessage(output: string): string {
+  const lines = output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+  const primary =
+    lines.find((line) => /No matching version found|permission denied|network|ENOSPC/iu.test(line)) ??
+    lines.find((line) => /^\[ERR_[A-Z0-9_]+\]/u.test(line)) ??
+    lines.find((line) => /^npm\s+(?:error|ERR!)/iu.test(line) && !/\s+code\s+/iu.test(line)) ??
+    undefined
+  if (!primary) return '子进程返回非零状态，未识别到 npm/pnpm 错误码'
+  const cleaned = redactSensitive(
+    primary.replace(/^\[[A-Z][A-Z0-9_]+\]\s*/u, '').replace(/^npm\s+(?:error|ERR!)\s*/iu, ''),
+  )
+  return cleaned.length > 500 ? `${cleaned.slice(0, 500)}…` : cleaned
+}
+
+function suggestedAction(errorCode: string | undefined): string {
+  if (errorCode === 'ETARGET' || errorCode === 'ERR_PNPM_NO_MATCHING_VERSION') {
+    return '当前 registry 可能缺少该版本，请确认包版本和 registry 配置，必要时切换 registry 后重试。'
+  }
+  if (errorCode === 'E401' || errorCode === 'E403') {
+    return '请检查 registry 登录状态和包访问权限后重试。'
+  }
+  if (errorCode === 'EACCES' || errorCode === 'EPERM') {
+    return '请检查 npm 全局目录和目标目录权限后重试。'
+  }
+  if (['ENOTFOUND', 'ECONNRESET', 'ETIMEDOUT', 'ENETUNREACH', 'EAI_AGAIN'].includes(errorCode ?? '')) {
+    return '请检查网络、代理、DNS 和 registry 可达性后重试。'
+  }
+  if (errorCode === 'ENOSPC') return '请清理磁盘空间后重试。'
+  return '请根据首要错误检查安装环境；如仍失败，请查看完整日志后重试。'
+}
+
+async function writeCommandLog(options: DiagnoseCommandFailureOptions): Promise<string | undefined> {
+  try {
+    const logsDir = path.join(options.stateDir, 'logs')
+    await mkdir(logsDir, { recursive: true, mode: 0o700 })
+    const timestamp = new Date().toISOString().replaceAll(':', '-').replaceAll('.', '-')
+    const logPath = path.join(logsDir, `setup-${timestamp}-${options.stage}-${randomUUID().slice(0, 8)}.log`)
+    const content = [
+      `timestamp: ${new Date().toISOString()}`,
+      `stage: ${options.stage}`,
+      'redacted: true',
+      `command: ${redactSensitive([options.command, ...options.args].join(' '))}`,
+      `exitCode: ${options.result.code}`,
+      '',
+      '--- stdout ---',
+      redactSensitive(options.result.stdout),
+      '',
+      '--- stderr ---',
+      redactSensitive(options.result.stderr),
+      '',
+    ].join('\n')
+    await writeFile(logPath, content, { encoding: 'utf8', mode: 0o600, flag: 'wx' })
+    return logPath
+  } catch {
+    return undefined
+  }
+}
+
+export async function diagnoseCommandFailure(options: DiagnoseCommandFailureOptions): Promise<InstallDiagnostic> {
+  const output = combinedOutput(options.result)
+  const errorCode = extractErrorCode(output)
+  return {
+    stage: options.stage,
+    errorCode,
+    primaryMessage: extractPrimaryMessage(output),
+    packageSpec: extractPackageSpec(output),
+    registry: extractRegistry(output),
+    dependency: extractDependency(output),
+    suggestedAction: suggestedAction(errorCode),
+    logPath: await writeCommandLog(options),
+  }
+}
+
+export function formatInstallFailure(title: string, diagnostic: InstallDiagnostic): string {
+  return [
+    title,
+    `阶段：${diagnostic.stage}`,
+    diagnostic.errorCode ? `错误码：${diagnostic.errorCode}` : undefined,
+    `原因：${diagnostic.primaryMessage}`,
+    diagnostic.packageSpec ? `包：${diagnostic.packageSpec}` : undefined,
+    diagnostic.registry ? `Registry：${diagnostic.registry}` : undefined,
+    diagnostic.dependency ? `依赖：${diagnostic.dependency}` : undefined,
+    `建议：${diagnostic.suggestedAction}`,
+    diagnostic.logPath ? `完整日志：${diagnostic.logPath}` : undefined,
+  ]
+    .filter((line): line is string => Boolean(line))
+    .join('\n')
+}

--- a/src/setup-machine.ts
+++ b/src/setup-machine.ts
@@ -1,6 +1,7 @@
 import path from 'node:path'
 
 import { accountStateDir, DEFAULT_ACCOUNT_ID } from './accounts.js'
+import { diagnoseCommandFailure, type InstallStage } from './install-diagnostics.js'
 import { OwnerBinding } from './owner.js'
 import {
   createSetupCheckpoint,
@@ -24,6 +25,7 @@ import {
 import {
   installedDshCredentialLayout,
   runPrivateAccountSetup,
+  type CommandResult,
   type CommandRunner,
   type RunGuidedSetupOptions,
   type SetupUi,
@@ -65,6 +67,14 @@ export interface MachineSetupError {
   code: 'approval_required' | 'command_failed' | 'configuration_failed' | 'dsh_upgrade_required' | 'environment_changed'
   stepId?: string
   approvalIds?: string[]
+  stage?: InstallStage
+  errorCode?: string
+  primaryMessage?: string
+  package?: string
+  registry?: string
+  dependency?: string
+  suggestedAction?: string
+  logPath?: string
 }
 
 export interface MachineSetupOutcome {
@@ -200,21 +210,59 @@ async function failStep(
   completed: Set<string>,
   stepId: string,
   code: MachineSetupError['code'],
+  details: Pick<
+    MachineSetupError,
+    'stage' | 'errorCode' | 'primaryMessage' | 'package' | 'registry' | 'dependency' | 'suggestedAction' | 'logPath'
+  > = {},
 ): Promise<MachineSetupOutcome> {
   const saved = await persistProgress(options, checkpoint, 'failed', completed)
-  return outcome(saved, 'failed', { error: { code, stepId } })
+  return outcome(saved, 'failed', { error: { code, stepId, ...details } })
 }
 
-function runCommand(runner: CommandRunner, command: string, args: string[]) {
+function runCommand(runner: CommandRunner, command: string, args: string[]): CommandResult {
   try {
     return runner.run(command, args)
-  } catch {
-    return undefined
+  } catch (error) {
+    return {
+      code: 127,
+      stdout: '',
+      stderr: error instanceof Error ? error.message : '子进程启动失败',
+    }
   }
 }
 
-function commandSucceeded(runner: CommandRunner, command: string, args: string[]): boolean {
-  return runCommand(runner, command, args)?.code === 0
+function installStage(stepId: 'install-dsh' | 'install-pnpm' | 'install-plugin'): InstallStage {
+  if (stepId === 'install-dsh') return 'dsh_install'
+  if (stepId === 'install-pnpm') return 'pnpm_install'
+  return 'plugin_install'
+}
+
+async function failCommandStep(
+  options: MachineSetupOptions,
+  checkpoint: SetupCheckpoint,
+  completed: Set<string>,
+  stepId: 'install-dsh' | 'install-pnpm' | 'install-plugin',
+  command: string,
+  args: string[],
+  result: CommandResult,
+): Promise<MachineSetupOutcome> {
+  const diagnostic = await diagnoseCommandFailure({
+    stage: installStage(stepId),
+    command,
+    args,
+    result,
+    stateDir: options.stateDir,
+  })
+  return failStep(options, checkpoint, completed, stepId, 'command_failed', {
+    stage: diagnostic.stage,
+    errorCode: diagnostic.errorCode,
+    primaryMessage: diagnostic.primaryMessage,
+    package: diagnostic.packageSpec,
+    registry: diagnostic.registry,
+    dependency: diagnostic.dependency,
+    suggestedAction: diagnostic.suggestedAction,
+    logPath: diagnostic.logPath,
+  })
 }
 
 function versionMajor(output: string): number {
@@ -324,32 +372,40 @@ async function continueMachineSetup(
 
   const actionIds = new Set(plan.actions.map((item) => item.id))
   if (actionIds.has('install-dsh') && !completed.has('install-dsh')) {
-    if (!commandSucceeded(options.runner, 'npm', ['install', '--global', '@deepseek-ai/dsh@latest'])) {
-      return failStep(options, checkpoint, completed, 'install-dsh', 'command_failed')
+    const args = ['install', '--global', '@deepseek-ai/dsh@latest']
+    const installedDsh = runCommand(options.runner, 'npm', args)
+    if (installedDsh.code !== 0) {
+      return failCommandStep(options, checkpoint, completed, 'install-dsh', 'npm', args, installedDsh)
     }
-    if (!commandSucceeded(options.runner, 'dsh', ['--version'])) {
-      return failStep(options, checkpoint, completed, 'install-dsh', 'command_failed')
+    const versionArgs = ['--version']
+    const installedVersion = runCommand(options.runner, 'dsh', versionArgs)
+    if (installedVersion.code !== 0) {
+      return failCommandStep(options, checkpoint, completed, 'install-dsh', 'dsh', versionArgs, installedVersion)
     }
     completed.add('install-dsh')
     checkpoint = await persistProgress(options, checkpoint, 'applying', completed)
   }
 
   if (actionIds.has('install-pnpm') && !completed.has('install-pnpm')) {
-    if (!commandSucceeded(options.runner, 'npm', ['install', '--global', 'pnpm@latest'])) {
-      return failStep(options, checkpoint, completed, 'install-pnpm', 'command_failed')
+    const args = ['install', '--global', 'pnpm@latest']
+    const installed = runCommand(options.runner, 'npm', args)
+    if (installed.code !== 0) {
+      return failCommandStep(options, checkpoint, completed, 'install-pnpm', 'npm', args, installed)
     }
     const installedPnpm = runCommand(options.runner, 'pnpm', ['--version'])
-    const installedPnpmMajor = installedPnpm ? versionMajor(installedPnpm.stdout) : Number.NaN
-    if (installedPnpm?.code !== 0 || !Number.isFinite(installedPnpmMajor) || installedPnpmMajor < 11) {
-      return failStep(options, checkpoint, completed, 'install-pnpm', 'command_failed')
+    const installedPnpmMajor = versionMajor(installedPnpm.stdout)
+    if (installedPnpm.code !== 0 || !Number.isFinite(installedPnpmMajor) || installedPnpmMajor < 11) {
+      return failCommandStep(options, checkpoint, completed, 'install-pnpm', 'pnpm', ['--version'], installedPnpm)
     }
     completed.add('install-pnpm')
     checkpoint = await persistProgress(options, checkpoint, 'applying', completed)
   }
 
   if (!completed.has('install-plugin')) {
-    if (!commandSucceeded(options.runner, 'dsh', ['plugin', '--profile', 'web', 'add', options.installSpec])) {
-      return failStep(options, checkpoint, completed, 'install-plugin', 'command_failed')
+    const args = ['plugin', '--profile', 'web', 'add', options.installSpec]
+    const installed = runCommand(options.runner, 'dsh', args)
+    if (installed.code !== 0) {
+      return failCommandStep(options, checkpoint, completed, 'install-plugin', 'dsh', args, installed)
     }
     completed.add('install-plugin')
     checkpoint = await persistProgress(options, checkpoint, 'applying', completed)

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -2,6 +2,7 @@ import path from 'node:path'
 
 import { accountStateDir, assertAccountId, DEFAULT_ACCOUNT_ID } from './accounts.js'
 import { collectDiagnostics } from './diagnostics.js'
+import { diagnoseCommandFailure, formatInstallFailure } from './install-diagnostics.js'
 import { isSupportedNodeVersion } from './node-version.js'
 import { beginRegistration, renderQr, waitForCredentials } from './onboard.js'
 import { issueBindingChallenge, OwnerBinding } from './owner.js'
@@ -44,7 +45,7 @@ export interface SetupUi {
   note(message: string): void
   warn(message: string): void
   success(message: string): void
-  loading(message: string): () => void
+  loading(message: string): (succeeded: boolean, completedMessage: string) => void
   confirm(id: string, message: string, initial: boolean): Promise<boolean>
   select<T extends string>(id: string, message: string, options: readonly SelectOption<T>[], initial: T): Promise<T>
   text(id: string, message: string): Promise<string>
@@ -55,15 +56,18 @@ export interface SetupUi {
 async function runWithLoading(
   ui: SetupUi,
   runner: CommandRunner,
-  message: string,
+  messages: { running: string; succeeded: string; failed: string },
   command: string,
   args: string[],
 ): Promise<CommandResult> {
-  const stopLoading = ui.loading(message)
+  const stopLoading = ui.loading(messages.running)
   try {
-    return runner.run(command, args)
-  } finally {
-    stopLoading()
+    const result = runner.run(command, args)
+    stopLoading(result.code === 0, result.code === 0 ? messages.succeeded : messages.failed)
+    return result
+  } catch (error) {
+    stopLoading(false, messages.failed)
+    throw error
   }
 }
 
@@ -164,20 +168,53 @@ export function installedDshCredentialLayout(runner: CommandRunner): CredentialD
   return credentialLayoutForDshVersion(version)
 }
 
-async function ensureDshInstalled(ui: SetupUi, runner: CommandRunner): Promise<boolean> {
-  let installed = await runWithLoading(ui, runner, '正在检查 DeepSeek Harness…', 'dsh', ['--version'])
+async function ensureDshInstalled(ui: SetupUi, runner: CommandRunner, stateDir: string): Promise<boolean> {
+  let installed = await runWithLoading(
+    ui,
+    runner,
+    {
+      running: '正在检查 DeepSeek Harness…',
+      succeeded: 'DeepSeek Harness 检查完成',
+      failed: '未检测到 DeepSeek Harness',
+    },
+    'dsh',
+    ['--version'],
+  )
   if (installed.code !== 0) {
     if (!(await ui.confirm('installDsh', '未检测到 DeepSeek Harness，是否安装最新版？', true))) return false
-    const install = await runWithLoading(ui, runner, '正在安装最新版 DeepSeek Harness…', 'npm', [
-      'install',
-      '--global',
-      '@deepseek-ai/dsh@latest',
-    ])
+    const install = await runWithLoading(
+      ui,
+      runner,
+      {
+        running: '正在安装最新版 DeepSeek Harness…',
+        succeeded: '最新版 DeepSeek Harness 安装完成',
+        failed: 'DeepSeek Harness 安装失败',
+      },
+      'npm',
+      ['install', '--global', '@deepseek-ai/dsh@latest'],
+    )
     if (install.code !== 0) {
-      ui.warn(`DSH 安装失败：${install.stderr.trim() || 'npm 返回非零状态'}`)
+      const diagnostic = await diagnoseCommandFailure({
+        stage: 'dsh_install',
+        command: 'npm',
+        args: ['install', '--global', '@deepseek-ai/dsh@latest'],
+        result: install,
+        stateDir,
+      })
+      ui.warn(formatInstallFailure('DSH 安装失败', diagnostic))
       return false
     }
-    installed = await runWithLoading(ui, runner, '正在确认 DeepSeek Harness 安装结果…', 'dsh', ['--version'])
+    installed = await runWithLoading(
+      ui,
+      runner,
+      {
+        running: '正在确认 DeepSeek Harness 安装结果…',
+        succeeded: 'DeepSeek Harness 安装结果确认完成',
+        failed: 'DeepSeek Harness 安装结果确认失败',
+      },
+      'dsh',
+      ['--version'],
+    )
     if (installed.code !== 0) {
       ui.warn('DSH 安装完成后仍无法执行，请检查全局 npm bin 是否在 PATH。')
       return false
@@ -187,8 +224,14 @@ async function ensureDshInstalled(ui: SetupUi, runner: CommandRunner): Promise<b
   return true
 }
 
-async function ensurePnpm(ui: SetupUi, runner: CommandRunner): Promise<boolean> {
-  let current = await runWithLoading(ui, runner, '正在检查 pnpm 版本…', 'pnpm', ['--version'])
+async function ensurePnpm(ui: SetupUi, runner: CommandRunner, stateDir: string): Promise<boolean> {
+  let current = await runWithLoading(
+    ui,
+    runner,
+    { running: '正在检查 pnpm 版本…', succeeded: 'pnpm 版本检查完成', failed: 'pnpm 版本检查失败' },
+    'pnpm',
+    ['--version'],
+  )
   const major = Number(cleanVersion(current.stdout).split('.')[0])
   if (current.code === 0 && Number.isFinite(major) && major >= 11) return true
 
@@ -200,16 +243,31 @@ async function ensurePnpm(ui: SetupUi, runner: CommandRunner): Promise<boolean> 
   )
   if (!install) return false
 
-  const installed = await runWithLoading(ui, runner, '正在安装最新版 pnpm…', 'npm', [
-    'install',
-    '--global',
-    'pnpm@latest',
-  ])
+  const installed = await runWithLoading(
+    ui,
+    runner,
+    { running: '正在安装最新版 pnpm…', succeeded: '最新版 pnpm 安装完成', failed: 'pnpm 安装失败' },
+    'npm',
+    ['install', '--global', 'pnpm@latest'],
+  )
   if (installed.code !== 0) {
-    ui.warn(`pnpm 安装失败：${installed.stderr.trim() || 'npm 返回非零状态'}`)
+    const diagnostic = await diagnoseCommandFailure({
+      stage: 'pnpm_install',
+      command: 'npm',
+      args: ['install', '--global', 'pnpm@latest'],
+      result: installed,
+      stateDir,
+    })
+    ui.warn(formatInstallFailure('pnpm 安装失败', diagnostic))
     return false
   }
-  current = await runWithLoading(ui, runner, '正在确认 pnpm 安装结果…', 'pnpm', ['--version'])
+  current = await runWithLoading(
+    ui,
+    runner,
+    { running: '正在确认 pnpm 安装结果…', succeeded: 'pnpm 安装结果确认完成', failed: 'pnpm 安装结果确认失败' },
+    'pnpm',
+    ['--version'],
+  )
   if (current.code !== 0 || Number(cleanVersion(current.stdout).split('.')[0]) < 11) {
     ui.warn('pnpm 安装后仍不可用或版本过旧，请检查全局 npm bin 和 PATH。')
     return false
@@ -372,15 +430,22 @@ async function configureFeatures(
   await updateWebProfileConfig(dshHome, { dwsEnabled, imageMode })
   await configureAccess(options, accountId, defaultAccessToAll)
   if (dwsEnabled) {
-    const version = await runWithLoading(ui, runner, '正在检查 DWS CLI…', 'dws', ['--version'])
+    const version = await runWithLoading(
+      ui,
+      runner,
+      { running: '正在检查 DWS CLI…', succeeded: 'DWS CLI 检查完成', failed: 'DWS CLI 检查失败' },
+      'dws',
+      ['--version'],
+    )
     if (version.code !== 0) ui.warn('已开启 DWS，但本机未检测到 dws CLI；钉钉消息能力不受影响。')
     else {
-      const auth = await runWithLoading(ui, runner, '正在检查 DWS 登录状态…', 'dws', [
-        'auth',
-        'status',
-        '--format',
-        'json',
-      ])
+      const auth = await runWithLoading(
+        ui,
+        runner,
+        { running: '正在检查 DWS 登录状态…', succeeded: 'DWS 登录状态检查完成', failed: 'DWS 登录状态检查失败' },
+        'dws',
+        ['auth', 'status', '--format', 'json'],
+      )
       if (auth.code !== 0) ui.warn('DWS 尚未登录；请稍后执行 dws auth login。')
     }
   }
@@ -555,18 +620,29 @@ export async function runGuidedSetup(options: RunGuidedSetupOptions): Promise<Gu
     ui.warn(`当前 Node.js ${process.versions.node}，要求 ^22.19.0 或 >=24.0.0。`)
     return { code: 2, startWeb: false }
   }
-  if (!(await ensureDshInstalled(ui, runner))) return { code: 2, startWeb: false }
-  if (!(await ensurePnpm(ui, runner))) return { code: 2, startWeb: false }
+  if (!(await ensureDshInstalled(ui, runner, stateDir))) return { code: 2, startWeb: false }
+  if (!(await ensurePnpm(ui, runner, stateDir))) return { code: 2, startWeb: false }
 
-  const installed = await runWithLoading(ui, runner, '正在安装 DSH web profile 插件…', 'dsh', [
-    'plugin',
-    '--profile',
-    'web',
-    'add',
-    installSpec,
-  ])
+  const installed = await runWithLoading(
+    ui,
+    runner,
+    {
+      running: '正在安装 DSH web profile 插件…',
+      succeeded: 'DSH web profile 插件安装完成',
+      failed: 'DSH web profile 插件安装失败',
+    },
+    'dsh',
+    ['plugin', '--profile', 'web', 'add', installSpec],
+  )
   if (installed.code !== 0) {
-    ui.warn(`插件安装失败：${installed.stderr.trim() || 'dsh plugin 返回非零状态'}`)
+    const diagnostic = await diagnoseCommandFailure({
+      stage: 'plugin_install',
+      command: 'dsh',
+      args: ['plugin', '--profile', 'web', 'add', installSpec],
+      result: installed,
+      stateDir,
+    })
+    ui.warn(formatInstallFailure('插件安装失败', diagnostic))
     return { code: 1, startWeb: false }
   }
   ui.success(`插件已安装到 DSH web profile：${installSpec}`)

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -56,6 +56,8 @@ test('公开 setup CLI 在一个进程内完成插件安装和配置', async (t)
 
   assert.equal(result.status, 0, result.stderr || result.stdout)
   assert.match(result.stdout, /⏳ 正在安装 DSH web profile 插件…/)
+  assert.match(result.stdout, /✅ DSH web profile 插件安装完成/)
+  assert.doesNotMatch(result.stdout, /✅ 正在/)
   assert.match(result.stdout, /插件已安装到 DSH web profile/)
   assert.match(result.stdout, /\/bind [A-Z0-9]+/)
   assert.doesNotMatch(result.stdout, /secret-cli/)
@@ -66,6 +68,65 @@ test('公开 setup CLI 在一个进程内完成插件安装和配置', async (t)
     DINGTALK_CLIENT_ID: 'ding-cli',
     DINGTALK_CLIENT_SECRET: 'secret-cli',
   })
+})
+
+test('公开 setup CLI 用失败图标和摘要展示插件安装根因', async (t) => {
+  if (process.platform === 'win32') return
+  const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-cli-failure-'))
+  t.after(() => import('node:fs/promises').then((fs) => fs.rm(root, { recursive: true, force: true })))
+  const bin = path.join(root, 'bin')
+  await import('node:fs/promises').then((fs) => fs.mkdir(bin, { recursive: true }))
+  await writeFile(
+    path.join(bin, 'dsh'),
+    [
+      '#!/bin/sh',
+      'if [ "$1" = "--version" ]; then echo 0.1.1-rc.2; exit 0; fi',
+      'pnpm "$4" "$5"',
+      'status=$?',
+      'echo "dsh: pnpm failed in profile directory $DSH_HOME/profiles/web" >&2',
+      'exit $status',
+      '',
+    ].join('\n'),
+  )
+  await writeFile(
+    path.join(bin, 'pnpm'),
+    [
+      '#!/bin/sh',
+      'if [ "$1" = "--version" ]; then echo 11.7.0; exit 0; fi',
+      'echo "Progress: resolved 20, reused 19, downloaded 0, added 0"',
+      'echo "[ERR_PNPM_NO_MATCHING_VERSION] No matching version found for @deepseek-ai/dsh-fs-local@^0.1.1-rc.2"',
+      'echo "while fetching it from https://packages.example.test/"',
+      'exit 1',
+      '',
+    ].join('\n'),
+  )
+  await chmod(path.join(bin, 'dsh'), 0o755)
+  await chmod(path.join(bin, 'pnpm'), 0o755)
+
+  const result = spawnSync(process.execPath, ['lib/bin.js', 'setup'], {
+    cwd: path.resolve('.'),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      HOME: root,
+      DSH_HOME: path.join(root, '.dsh'),
+      DSH_DINGTALK_STATE_DIR: path.join(root, '.dsh-dingtalk'),
+      PATH: `${bin}${path.delimiter}${process.env.PATH ?? ''}`,
+    },
+    timeout: 10_000,
+  })
+
+  assert.equal(result.status, 1, result.stderr || result.stdout)
+  assert.match(result.stdout, /⏳ 正在安装 DSH web profile 插件…/)
+  assert.match(result.stdout, /❌ DSH web profile 插件安装失败/)
+  assert.doesNotMatch(result.stdout, /✅ 正在安装 DSH web profile 插件/)
+  assert.match(result.stderr, /错误码：ERR_PNPM_NO_MATCHING_VERSION/)
+  assert.match(result.stderr, /包：@deepseek-ai\/dsh-fs-local@\^0\.1\.1-rc\.2/)
+  assert.match(result.stderr, /Registry：https:\/\/packages\.example\.test\//)
+  assert.doesNotMatch(result.stderr, /Progress: resolved/)
+  const logPath = result.stderr.match(/完整日志：(.+)/)?.[1]
+  assert.ok(logPath)
+  assert.match(await readFile(logPath, 'utf8'), /Progress: resolved 20/)
 })
 
 test('doctor 识别 web profile 中显式配置的管理员', async (t) => {

--- a/test/setup-flow.test.mjs
+++ b/test/setup-flow.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { mkdtemp, readFile } from 'node:fs/promises'
+import { mkdtemp, readFile, stat } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
@@ -94,6 +94,93 @@ class OldPnpmRunner extends FakeRunner {
   }
 }
 
+class PluginFailureRunner extends FakeRunner {
+  run(command, args) {
+    if (command === 'dsh' && args[0] === 'plugin') {
+      this.calls.push([command, ...args])
+      return { code: 1, stdout: '', stderr: 'plugin install failed' }
+    }
+    return super.run(command, args)
+  }
+}
+
+class PluginPnpmFailureRunner extends FakeRunner {
+  run(command, args) {
+    if (command === 'dsh' && args[0] === 'plugin') {
+      this.calls.push([command, ...args])
+      return {
+        code: 1,
+        stdout: [
+          'Progress: resolved 20, reused 19, downloaded 0, added 0',
+          '[ERR_PNPM_NO_MATCHING_VERSION] No matching version found for @deepseek-ai/dsh-fs-local@^0.1.1-rc.2',
+          'while fetching it from https://build-user:private-secret@packages.example.test/',
+          'This error happened while installing the dependencies of @deepseek-ai/dsh-base@0.1.1-rc.2',
+          '',
+        ].join('\n'),
+        stderr: [
+          'dsh: initialized profile web at /tmp/.dsh/profiles/web',
+          'dsh: pnpm failed in profile directory /tmp/.dsh/profiles/web',
+          '',
+        ].join('\n'),
+      }
+    }
+    return super.run(command, args)
+  }
+}
+
+class CategorizedPluginFailureRunner extends FakeRunner {
+  constructor(stderr) {
+    super()
+    this.stderr = stderr
+  }
+
+  run(command, args) {
+    if (command === 'dsh' && args[0] === 'plugin') {
+      this.calls.push([command, ...args])
+      return { code: 1, stdout: '', stderr: this.stderr }
+    }
+    return super.run(command, args)
+  }
+}
+
+class BootstrapInstallFailureRunner extends FakeRunner {
+  constructor(stage) {
+    super()
+    this.stage = stage
+  }
+
+  run(command, args) {
+    if (this.stage === 'dsh_install' && command === 'dsh' && args[0] === '--version') {
+      this.calls.push([command, ...args])
+      return { code: 127, stdout: '', stderr: 'command not found' }
+    }
+    if (this.stage === 'pnpm_install' && command === 'pnpm' && args[0] === '--version') {
+      this.calls.push([command, ...args])
+      return { code: 0, stdout: '9.5.0\n', stderr: '' }
+    }
+    if (command === 'npm' && args[0] === 'install') {
+      this.calls.push([command, ...args])
+      return {
+        code: 1,
+        stdout: 'npm progress noise\n',
+        stderr: 'npm error code ETARGET\nnpm error notarget No matching version found for bootstrap-package@1.2.3.\n',
+      }
+    }
+    return super.run(command, args)
+  }
+}
+
+class LoadingOutcomeUi extends FakeUi {
+  loadingOutcomes = []
+
+  loading(message) {
+    this.messages.push(`开始加载：${message}`)
+    return (succeeded, completedMessage) => {
+      this.loadingOutcomes.push({ message, succeeded, completedMessage })
+    }
+  }
+}
+
 class SwitchingDshRunner extends FakeRunner {
   dshChecks = 0
   run(command, args) {
@@ -114,6 +201,117 @@ test('setup 按实际 DSH 版本选择凭据文档格式', () => {
   assert.equal(credentialLayoutForDshVersion('0.1.1'), 'v1')
   assert.equal(credentialLayoutForDshVersion('1.0.0'), 'v1')
   assert.throws(() => credentialLayoutForDshVersion('not-a-version'), /无法识别 DSH 版本/)
+})
+
+test('插件安装失败时 loading 以失败态和完成态文案收尾', async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-plugin-loading-failure-'))
+  t.after(() => import('node:fs/promises').then((fs) => fs.rm(root, { recursive: true, force: true })))
+  const ui = new LoadingOutcomeUi()
+
+  const result = await runGuidedSetup({
+    ui,
+    runner: new PluginFailureRunner(),
+    dshHome: path.join(root, '.dsh'),
+    stateDir: path.join(root, '.dsh-dingtalk'),
+    installSpec: '@dingtalk-real-ai/dsh-dingtalk@0.6.0',
+  })
+
+  assert.equal(result.code, 1)
+  assert.deepEqual(ui.loadingOutcomes.at(-1), {
+    message: '正在安装 DSH web profile 插件…',
+    succeeded: false,
+    completedMessage: 'DSH web profile 插件安装失败',
+  })
+})
+
+test('插件安装失败时提取 pnpm 根因并保留完整日志', async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-plugin-diagnostic-'))
+  t.after(() => import('node:fs/promises').then((fs) => fs.rm(root, { recursive: true, force: true })))
+  const stateDir = path.join(root, '.dsh-dingtalk')
+  const ui = new FakeUi()
+
+  const result = await runGuidedSetup({
+    ui,
+    runner: new PluginPnpmFailureRunner(),
+    dshHome: path.join(root, '.dsh'),
+    stateDir,
+    installSpec: '@dingtalk-real-ai/dsh-dingtalk@0.6.0',
+  })
+
+  assert.equal(result.code, 1)
+  const displayed = ui.messages.join('\n')
+  assert.match(displayed, /插件安装失败/)
+  assert.match(displayed, /错误码：ERR_PNPM_NO_MATCHING_VERSION/)
+  assert.match(displayed, /包：@deepseek-ai\/dsh-fs-local@\^0\.1\.1-rc\.2/)
+  assert.match(displayed, /Registry：https:\/\/packages\.example\.test\//)
+  assert.match(displayed, /依赖：@deepseek-ai\/dsh-base@0\.1\.1-rc\.2/)
+  assert.doesNotMatch(displayed, /private-secret/)
+  assert.match(displayed, /建议：当前 registry 可能缺少该版本/)
+  assert.doesNotMatch(displayed, /Progress: resolved/)
+
+  const logPath = displayed.match(/完整日志：(.+)/)?.[1]
+  assert.ok(logPath)
+  assert.match(logPath, new RegExp(`^${path.join(stateDir, 'logs').replaceAll('\\', '\\\\')}`))
+  const log = await readFile(logPath, 'utf8')
+  assert.match(log, /Progress: resolved 20/)
+  assert.match(log, /dsh: pnpm failed in profile directory/)
+  assert.doesNotMatch(log, /private-secret/)
+  if (process.platform !== 'win32') assert.equal((await stat(logPath)).mode & 0o777, 0o600)
+})
+
+test('安装失败按权限、网络和磁盘错误给出可执行建议', async (t) => {
+  const cases = [
+    ['npm error code EACCES\nnpm error permission denied', /检查 npm 全局目录和目标目录权限/],
+    ['npm error code ENOTFOUND\nnpm error network registry unavailable', /检查网络、代理、DNS 和 registry 可达性/],
+    ['npm error code ENOSPC\nnpm error no space left on device', /清理磁盘空间后重试/],
+  ]
+
+  for (const [stderr, suggestion] of cases) {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-categorized-diagnostic-'))
+    t.after(() => import('node:fs/promises').then((fs) => fs.rm(root, { recursive: true, force: true })))
+    const ui = new FakeUi()
+    const result = await runGuidedSetup({
+      ui,
+      runner: new CategorizedPluginFailureRunner(stderr),
+      dshHome: path.join(root, '.dsh'),
+      stateDir: path.join(root, '.dsh-dingtalk'),
+      installSpec: '@dingtalk-real-ai/dsh-dingtalk@0.6.0',
+    })
+
+    assert.equal(result.code, 1)
+    assert.match(ui.messages.join('\n'), suggestion)
+  }
+})
+
+test('DSH 与 pnpm 安装失败共用结构化摘要和完整日志', async (t) => {
+  const cases = [
+    ['dsh_install', /DSH 安装失败/],
+    ['pnpm_install', /pnpm 安装失败/],
+  ]
+
+  for (const [stage, title] of cases) {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-bootstrap-diagnostic-'))
+    t.after(() => import('node:fs/promises').then((fs) => fs.rm(root, { recursive: true, force: true })))
+    const ui = new FakeUi()
+    const result = await runGuidedSetup({
+      ui,
+      runner: new BootstrapInstallFailureRunner(stage),
+      dshHome: path.join(root, '.dsh'),
+      stateDir: path.join(root, '.dsh-dingtalk'),
+      installSpec: '@dingtalk-real-ai/dsh-dingtalk@0.6.0',
+    })
+
+    assert.equal(result.code, 2)
+    const displayed = ui.messages.join('\n')
+    assert.match(displayed, title)
+    assert.match(displayed, new RegExp(`阶段：${stage}`))
+    assert.match(displayed, /错误码：ETARGET/)
+    assert.match(displayed, /包：bootstrap-package@1\.2\.3/)
+    assert.doesNotMatch(displayed, /npm progress noise/)
+    const logPath = displayed.match(/完整日志：(.+)/)?.[1]
+    assert.ok(logPath)
+    assert.match(await readFile(logPath, 'utf8'), /npm progress noise/)
+  }
 })
 
 test('setup 在交互完成后的实际写入点重新探测 DSH 版本', async (t) => {

--- a/test/setup-machine.test.mjs
+++ b/test/setup-machine.test.mjs
@@ -311,10 +311,17 @@ test('私密 resume 也拒绝改用 checkpoint 未批准的插件版本', async 
   await assert.rejects(() => stat(path.join(setupOptions.stateDir, 'owner.json')), { code: 'ENOENT' })
 })
 
-test('机器 setup 不把子进程错误原文带入结果或检查点', async (t) => {
+test('机器 setup 返回结构化安装诊断且不泄露子进程原文', async (t) => {
   const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-machine-error-'))
   t.after(() => import('node:fs/promises').then((fs) => fs.rm(root, { recursive: true, force: true })))
-  const runner = new FakeRunner({ pluginFailure: 'remote said private-secret' })
+  const runner = new FakeRunner({
+    pluginFailure: [
+      '[ERR_PNPM_NO_MATCHING_VERSION] No matching version found for @deepseek-ai/dsh-fs-local@^0.1.1-rc.2',
+      'while fetching it from https://build-user:private-secret@packages.example.test/',
+      'This error happened while installing the dependencies of @deepseek-ai/dsh-base@0.1.1-rc.2',
+      'npm error authToken=private-secret',
+    ].join('\n'),
+  })
   const setupOptions = options(root, runner)
   const plan = await planMachineSetup(setupOptions, { accountId: 'default' })
 
@@ -323,7 +330,16 @@ test('机器 setup 不把子进程错误原文带入结果或检查点', async (
   assert.equal(result.status, 'failed')
   assert.equal(result.error?.code, 'command_failed')
   assert.equal(result.error?.stepId, 'install-plugin')
+  assert.equal(result.error?.stage, 'plugin_install')
+  assert.equal(result.error?.errorCode, 'ERR_PNPM_NO_MATCHING_VERSION')
+  assert.match(result.error?.primaryMessage ?? '', /No matching version found/)
+  assert.equal(result.error?.package, '@deepseek-ai/dsh-fs-local@^0.1.1-rc.2')
+  assert.equal(result.error?.registry, 'https://packages.example.test/')
+  assert.equal(result.error?.dependency, '@deepseek-ai/dsh-base@0.1.1-rc.2')
+  assert.match(result.error?.suggestedAction ?? '', /当前 registry 可能缺少该版本/)
+  assert.match(result.error?.logPath ?? '', /[/\\]logs[/\\]setup-.+plugin_install-.+\.log$/)
   assert.doesNotMatch(JSON.stringify(result), /private-secret/)
+  assert.doesNotMatch(await readFile(result.error.logPath, 'utf8'), /private-secret/)
   const checkpointText = await readFile(
     path.join(setupOptions.stateDir, 'setup', 'checkpoints', `${result.checkpointId}.json`),
     'utf8',


### PR DESCRIPTION
## 用户影响
安装失败时不再被原始 npm 噪声淹没，也不会错误显示成功状态；人和 AI Agent 都能获得稳定诊断。

## 改动
- 提取 npm/pnpm 错误码、包、registry 与依赖上下文，并分类给出恢复建议
- 将完整脱敏日志以 0600 写入状态目录
- loading 使用完成态文案并按结果显示成功或失败图标
- setup 机器 JSON 返回稳定诊断字段且不泄露秘密

## 验证
- corepack pnpm run ci
- 167/167 tests passed
- secret scan, formatting, typecheck and npm tarball checks passed