### PR TITLE
fix(renderer): prevent empty cards for failed model turns

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -11,6 +11,13 @@ interface Rule {
   hint?: string
 }
 
+const CODE_RULES: Record<string, Omit<Rule, 'pattern'>> = {
+  MISSING_CREDENTIAL: {
+    label: '模型凭据未配置',
+    hint: '打开 dsh web 的 Models 页面补充对应模型凭据后重试',
+  },
+}
+
 const RULES: Rule[] = [
   { pattern: /\{\{model\}\}/, label: '会话未配置模型路由', hint: '用 /model use <provider>/<model> 指定后重试' },
   { pattern: /timed?.?out|ETIMEDOUT|deadline/i, label: '模型响应超时', hint: '稍后重发即可' },
@@ -38,12 +45,17 @@ const RULES: Rule[] = [
   { pattern: /5\d\d|internal server|service unavailable|无通道/i, label: '模型服务端错误', hint: '稍后重发即可' },
 ]
 
-/** Render a turn-ending error as a classified, actionable Chinese line. */
-export function describeTurnError(raw: string | undefined): string {
-  const message = (raw ?? '').trim() || 'unknown error'
-  const rule = RULES.find((r) => r.pattern.test(message))
+/** Render a turn-ending error as a classified, actionable Chinese message. */
+export function describeTurnError(raw: string | undefined, code?: string): string {
+  const message = (raw ?? '').trim()
+  const normalizedCode = (code ?? '').trim()
+  if (!message && !normalizedCode) return '⚠️ 本次回复失败，请查看 dsh web 日志'
+
+  const rule = CODE_RULES[normalizedCode] ?? RULES.find((candidate) => candidate.pattern.test(message))
   const label = rule?.label ?? '本轮执行出错'
   const hint = rule?.hint ? `（${rule.hint}）` : ''
-  const detail = message.length > 200 ? `${message.slice(0, 200)}…` : message
-  return `⚠️ **${label}**${hint}\n> ${detail}`
+  const lines = [`⚠️ **${label}**${hint}`]
+  if (normalizedCode) lines.push(`> 错误码：\`${normalizedCode}\``)
+  if (message) lines.push(`> ${message}`)
+  return lines.join('\n')
 }

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -15,6 +15,9 @@ import { AICard, CardCapabilityError, type CardTarget } from './aicard.js'
 import { cardTarget } from './targets.js'
 import { describeTurnError } from './errors.js'
 
+const EMPTY_MODEL_RESPONSE =
+  '⚠️ **模型本次未产出正文**\n> 可能是输出额度被推理占满，请调大 `max_tokens` 或更换模型后重试。'
+
 interface Segment {
   kind: 'text' | 'tool'
   text: string
@@ -253,8 +256,12 @@ export class Renderer {
     st.settle()
 
     const kind = reason?.kind
-    const errText = kind === 'error' ? describeTurnError(reason.error?.message) : ''
-    if (errText) this.deps.log(`turn ended in error: ${reason?.error?.message ?? 'unknown'}`)
+    const failure = reason?.failure ?? reason?.error
+    const failureMessage = typeof failure === 'string' ? failure : failure?.message
+    const failureCode =
+      typeof failure === 'object' && failure !== null && failure.code !== undefined ? String(failure.code) : undefined
+    const errText = kind === 'error' ? describeTurnError(failureMessage, failureCode) : ''
+    if (errText) this.deps.log(`turn ended in error: ${failureMessage ?? failureCode ?? 'unknown'}`)
     // 'aborted' is the host's cancellation variant (TurnEndReasonMap) — the
     // user already got its confirmation elsewhere, settle without publishing.
     const interrupted = kind === 'aborted'
@@ -284,7 +291,7 @@ export class Renderer {
     let text = st.carryOffset > 0 ? liveText.slice(st.carryOffset) : substance || liveText
     if (st.carryOffset > 0 && !text.trim()) text = substance ? '（完整内容见上方卡片）' : ''
     if (errText) text = text ? `${text}\n\n${errText}` : errText
-    if (!text) return
+    if (!text.trim()) text = EMPTY_MODEL_RESPONSE
 
     let card = !st.cardUnavailable && st.cardPromise ? await st.cardPromise : null
     if (card && st.needsRollover && (substance || errText)) {

--- a/test/renderer-failures.test.mjs
+++ b/test/renderer-failures.test.mjs
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { Renderer } from '../lib/renderer.js'
+
+function createHarness() {
+  const finished = []
+  const failed = []
+  const sent = []
+  const card = {
+    async stream() {},
+    async finish(text) {
+      finished.push(text)
+    },
+    async fail(text) {
+      failed.push(text)
+    },
+  }
+  const renderer = new Renderer({
+    config: {
+      replyMode: { direct: 'aicard', group: 'aicard' },
+      streaming: { enabled: true, throttleMs: 1, maxCardChars: 20_000 },
+      asyncMode: false,
+      ackText: 'ack',
+      markdownTitle: 'DSH',
+      emotionFirstResponse: false,
+    },
+    outbound: {
+      async sendMarkdown(_webhook, _title, text) {
+        sent.push(text)
+        return true
+      },
+      async sendText(_webhook, text) {
+        sent.push(text)
+        return true
+      },
+    },
+    emotion: { async recall() {} },
+    async createCard() {
+      return card
+    },
+    log() {},
+  })
+  const msg = {
+    msgId: 'm1',
+    conversationId: 'c1',
+    conversationType: 'direct',
+    senderStaffId: 'u1',
+    senderNick: 'Raph',
+    text: '你好',
+    createAt: '1',
+    sessionWebhook: 'https://example.test',
+  }
+  return { renderer, msg, finished, failed, sent }
+}
+
+async function settleTurn(harness, reason) {
+  const settled = harness.renderer.onInbound('s1', harness.msg)
+  harness.renderer.onSessionEvent({ id: 's1' }, { type: 'turn/end', data: { reason } })
+  await settled
+  await new Promise((resolve) => setImmediate(resolve))
+}
+
+test('模型回合失败时向卡片透传 code、message 和可执行提示', async () => {
+  const harness = createHarness()
+  const message =
+    'llm-pi-ai: no credential for provider route "idealab-peach"; its profile resolves IDEALAB_PEACH_API_KEY, which is not set — store IDEALAB_PEACH_API_KEY through the credentials service (the web Models page writes it) or export it'
+
+  await settleTurn(harness, {
+    kind: 'error',
+    failure: { code: 'MISSING_CREDENTIAL', message },
+  })
+
+  assert.equal(harness.failed.length, 1)
+  assert.equal(harness.finished.length, 0)
+  assert.match(harness.failed[0], /模型凭据未配置/)
+  assert.match(harness.failed[0], /MISSING_CREDENTIAL/)
+  assert.match(harness.failed[0], /idealab-peach/)
+  assert.match(harness.failed[0], /IDEALAB_PEACH_API_KEY/)
+  assert.match(harness.failed[0], /credentials service/)
+  assert.match(harness.failed[0], /dsh web/)
+})
+
+test('模型正常结束但最终正文为空时给出可读说明', async () => {
+  const harness = createHarness()
+
+  await settleTurn(harness, { kind: 'completed' })
+
+  assert.equal(harness.failed.length, 0)
+  assert.equal(harness.finished.length, 1)
+  assert.match(harness.finished[0], /模型本次未产出正文/)
+  assert.match(harness.finished[0], /max_tokens/)
+  assert.match(harness.finished[0], /更换模型/)
+})
+
+test('模型失败但拿不到错误详情时仍不发送空白卡片', async () => {
+  const harness = createHarness()
+
+  await settleTurn(harness, { kind: 'error', failure: {} })
+
+  assert.equal(harness.failed.length, 1)
+  assert.equal(harness.failed[0], '⚠️ 本次回复失败，请查看 dsh web 日志')
+})


### PR DESCRIPTION
## 用户影响

模型回合失败或最终正文为空时，钉钉端不再只显示一张空白 AI Card。用户现在能看到具体错误、错误码和下一步动作；模型未产出正文时也会收到可读提示。

## 实现

- 兼容 `turn/end` 中的 `reason.failure` 与 `reason.error`，透传 `code` 和完整 `message`。
- 将 `MISSING_CREDENTIAL` 映射为“模型凭据未配置”，提示前往 dsh web 的 Models 页面补充凭据。
- 正常结束但最终正文为空时，提示调大 `max_tokens` 或更换模型。
- 错误详情缺失时使用固定兜底文案，保证不会推送空内容卡片。
- 新增渲染器回归测试，覆盖错误回合、空正文和无详情错误三条路径。

## 验证

环境：macOS，Node.js 22，pnpm 11.7.0。

| 检查 | 结果 |
| --- | --- |
| `corepack pnpm run ci` | 通过 |
| 单元与运行时测试 | 170/170 通过 |
| Prettier / TypeScript / secrets scan | 通过 |
| NPM tarball 校验 | 通过，183 files |

## 已知限制

- 已验证连接器的真实 `session/event` 渲染边界和 AI Card 调用契约；本地测试没有向真实钉钉会话投递卡片。
- 仓库不手工维护 `[Unreleased]` Changelog；发布说明由 semantic-release 生成。

## 风险与回滚

风险较低，变更仅影响回合结束时的错误/空正文渲染。若需回滚，可 revert `cef34030d773d3979953a7f7842c99e816bf1001`。
