### PR TITLE
fix(setup): propagate npm registry to pnpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,25 @@ The guide checks DSH and pnpm, asks before installing a missing or incompatible 
 
 `npx` runs the CLI for this invocation and does not add `dsh-dingtalk` to PATH. New accounts initially allow all senders and groups; for personal use, prefer owner-only sender access and no group access, then expand deliberately.
 
+### Enterprise private npm registries
+
+While DSH is in prerelease, the registry must contain the matching prerelease versions of the main package and all of its child packages. Enterprise registries such as Nexus, Verdaccio, or self-hosted cnpm can fail with `ETARGET`, `notarget`, or `ERR_PNPM_NO_MATCHING_VERSION` when only some packages have synchronized. This means the selected registry is missing a required version; it is not a connector configuration error.
+
+Before installing the plugin, setup reads `npm config get registry` and writes the registry without URL-embedded credentials to `$DSH_HOME/profiles/web/.npmrc` (default: `~/.dsh/profiles/web/.npmrc`). This keeps the outer npm process and the pnpm process launched by DSH on the same registry while preserving scoped registries, authentication, and other existing `.npmrc` settings. If the enterprise registry is incomplete, retry once with a registry that has the complete package set; the override now also reaches the later pnpm step:
+
+```bash
+npm_config_registry=https://registry.npmjs.org npx @dingtalk-real-ai/dsh-dingtalk@latest setup
+```
+
+You can also set and verify the web profile's project-level registry manually. Replace the directory when using a custom `DSH_HOME`:
+
+```bash
+mkdir -p ~/.dsh/profiles/web
+cd ~/.dsh/profiles/web
+npm config set registry https://registry.npmjs.org --location=project
+pnpm config get registry
+```
+
 ## How to use it: manual steps or assisted execution
 
 You can mix both modes, and you always start the task:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -120,6 +120,25 @@ npx @dingtalk-real-ai/dsh-dingtalk@latest setup
 
 `npx` 只运行本次 CLI，不会把 `dsh-dingtalk` 写入 PATH。首次安装的新机器人默认允许所有发送者和所有群；个人使用建议改为“仅管理员”和“禁止群聊”，再按需放开。
 
+### 企业私有 npm 源
+
+DSH 处于预发布阶段时，主包及其子包的预发布版本必须在 registry 中完整同步。Nexus、Verdaccio、自建 cnpm 等企业私有源若只同步了主包或部分子包，安装可能报 `ETARGET`、`notarget` 或 `ERR_PNPM_NO_MATCHING_VERSION`；这表示当前 registry 缺少所需版本，不是连接器配置错误。
+
+setup 会在安装插件前读取 `npm config get registry`，并把不含 URL 内嵌凭据的 registry 写入 `$DSH_HOME/profiles/web/.npmrc`（默认 `~/.dsh/profiles/web/.npmrc`），让外层 npm 与 DSH 拉起的 pnpm 使用同一个源。已有 scoped registry、认证和其他 `.npmrc` 配置会保留。若企业源缺包，可用一个已同步完整的源重试；该覆盖会同时传到后续 pnpm：
+
+```bash
+npm_config_registry=https://registry.npmjs.org npx @dingtalk-real-ai/dsh-dingtalk@latest setup
+```
+
+也可以手动设置并验证 web profile 的目录级配置；自定义 `DSH_HOME` 时请替换目录：
+
+```bash
+mkdir -p ~/.dsh/profiles/web
+cd ~/.dsh/profiles/web
+npm config set registry https://registry.npmjs.org --location=project
+pnpm config get registry
+```
+
 ## 怎么使用：手动操作或让机器人协助执行
 
 两种方式可以混用，始终由你发起任务：

--- a/src/install-diagnostics.ts
+++ b/src/install-diagnostics.ts
@@ -113,7 +113,7 @@ function extractPrimaryMessage(output: string): string {
 
 function suggestedAction(errorCode: string | undefined): string {
   if (errorCode === 'ETARGET' || errorCode === 'ERR_PNPM_NO_MATCHING_VERSION') {
-    return '当前 registry 可能缺少该版本，请确认包版本和 registry 配置，必要时切换 registry 后重试。'
+    return '当前 registry 可能缺少该版本。可用 npm_config_registry=<可用 registry> npx @dingtalk-real-ai/dsh-dingtalk@latest setup 重试；setup 会把该 registry 同步给 DSH 内部的 pnpm。也可在 ~/.dsh/profiles/web/.npmrc（自定义 DSH_HOME 时使用 $DSH_HOME/profiles/web/.npmrc）写入 registry=<可用 registry>。'
   }
   if (errorCode === 'E401' || errorCode === 'E403') {
     return '请检查 registry 登录状态和包访问权限后重试。'

--- a/src/install-diagnostics.ts
+++ b/src/install-diagnostics.ts
@@ -54,6 +54,7 @@ function extractErrorCode(output: string): string | undefined {
   if (bracketed) return bracketed
   const npmCode = output.match(/npm\s+(?:error|ERR!)\s+code\s+([A-Z][A-Z0-9_]*)/iu)?.[1]
   if (npmCode) return npmCode.toUpperCase()
+  if (/npm\s+(?:error|ERR!)\s+notarget\b/iu.test(output)) return 'ETARGET'
   return KNOWN_ERROR_CODES.find((code) => new RegExp(`(?:^|\\s)${code}(?:\\s|:|$)`, 'mu').test(output))
 }
 

--- a/src/npm-registry.ts
+++ b/src/npm-registry.ts
@@ -1,0 +1,73 @@
+import { randomUUID } from 'node:crypto'
+import { chmod, mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import { withRecoverableFileLock } from './file-lock.js'
+import type { CommandRunner } from './setup.js'
+
+const REGISTRY_LINE = /^\s*registry\s*=/iu
+
+function normalizeRegistry(value: string): string {
+  let registry: URL
+  try {
+    registry = new URL(value.trim())
+  } catch {
+    throw new Error('npm 返回了无效 registry；请先运行 npm config get registry 检查配置')
+  }
+  if (registry.protocol !== 'https:' && registry.protocol !== 'http:') {
+    throw new Error('npm registry 必须使用 http 或 https URL')
+  }
+
+  // registry URL 不应承载凭据；认证继续由用户级 .npmrc 的 scoped 配置提供。
+  registry.username = ''
+  registry.password = ''
+  return registry.toString()
+}
+
+function updateRegistryContent(source: string, registry: string): string {
+  const lines = source.split(/\r?\n/u).filter((line) => !REGISTRY_LINE.test(line))
+  while (lines.at(-1) === '') lines.pop()
+  return `${lines.length ? `${lines.join('\n')}\n` : ''}registry=${registry}\n`
+}
+
+async function readOptional(file: string): Promise<string> {
+  try {
+    return await readFile(file, 'utf8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return ''
+    throw error
+  }
+}
+
+async function atomicPrivateWrite(file: string, content: string): Promise<void> {
+  await mkdir(path.dirname(file), { recursive: true, mode: 0o700 })
+  const temporary = `${file}.tmp.${process.pid}.${randomUUID()}`
+  try {
+    await writeFile(temporary, content, { encoding: 'utf8', flag: 'wx', mode: 0o600 })
+    await rename(temporary, file)
+    await chmod(file, 0o600)
+  } finally {
+    await rm(temporary, { force: true })
+  }
+}
+
+export async function syncWebProfileNpmRegistry(dshHome: string, runner: CommandRunner): Promise<string> {
+  let result
+  try {
+    result = runner.run('npm', ['config', 'get', 'registry'])
+  } catch {
+    throw new Error('无法读取当前 npm registry；请先运行 npm config get registry 检查配置')
+  }
+  if (result.code !== 0) {
+    throw new Error('无法读取当前 npm registry；请先运行 npm config get registry 检查配置')
+  }
+
+  const registry = normalizeRegistry(result.stdout)
+  const file = path.join(dshHome, 'profiles', 'web', '.npmrc')
+  await withRecoverableFileLock(
+    `${file}.lock`,
+    async () => atomicPrivateWrite(file, updateRegistryContent(await readOptional(file), registry)),
+    { label: 'web profile npm registry' },
+  )
+  return registry
+}

--- a/src/setup-machine.ts
+++ b/src/setup-machine.ts
@@ -2,6 +2,7 @@ import path from 'node:path'
 
 import { accountStateDir, DEFAULT_ACCOUNT_ID } from './accounts.js'
 import { diagnoseCommandFailure, type InstallStage } from './install-diagnostics.js'
+import { syncWebProfileNpmRegistry } from './npm-registry.js'
 import { OwnerBinding } from './owner.js'
 import {
   createSetupCheckpoint,
@@ -402,6 +403,13 @@ async function continueMachineSetup(
   }
 
   if (!completed.has('install-plugin')) {
+    try {
+      await syncWebProfileNpmRegistry(options.dshHome, options.runner)
+    } catch (error) {
+      return failStep(options, checkpoint, completed, 'install-plugin', 'configuration_failed', {
+        primaryMessage: error instanceof Error ? error.message : '无法同步 npm registry 到 DSH web profile',
+      })
+    }
     const args = ['plugin', '--profile', 'web', 'add', options.installSpec]
     const installed = runCommand(options.runner, 'dsh', args)
     if (installed.code !== 0) {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -4,6 +4,7 @@ import { accountStateDir, assertAccountId, DEFAULT_ACCOUNT_ID } from './accounts
 import { collectDiagnostics } from './diagnostics.js'
 import { diagnoseCommandFailure, formatInstallFailure } from './install-diagnostics.js'
 import { isSupportedNodeVersion } from './node-version.js'
+import { syncWebProfileNpmRegistry } from './npm-registry.js'
 import { beginRegistration, renderQr, waitForCredentials } from './onboard.js'
 import { issueBindingChallenge, OwnerBinding } from './owner.js'
 import {
@@ -622,6 +623,13 @@ export async function runGuidedSetup(options: RunGuidedSetupOptions): Promise<Gu
   }
   if (!(await ensureDshInstalled(ui, runner, stateDir))) return { code: 2, startWeb: false }
   if (!(await ensurePnpm(ui, runner, stateDir))) return { code: 2, startWeb: false }
+
+  try {
+    await syncWebProfileNpmRegistry(dshHome, runner)
+  } catch (error) {
+    ui.warn(error instanceof Error ? error.message : '无法同步 npm registry 到 DSH web profile')
+    return { code: 1, startWeb: false }
+  }
 
   const installed = await runWithLoading(
     ui,

--- a/test/ai-native-cli.test.mjs
+++ b/test/ai-native-cli.test.mjs
@@ -64,8 +64,9 @@ async function fixture(t) {
     windows: '@echo off\r\necho pnpm %*>>"%DSH_TEST_CALL_LOG%"\r\necho 11.7.0\r\nexit /b 0\r\n',
   })
   await writeFixtureCommand(bin, 'npm', {
-    posix: `#!/bin/sh\necho "npm $*" >> "$DSH_TEST_CALL_LOG"\nexit 0\n`,
-    windows: '@echo off\r\necho npm %*>>"%DSH_TEST_CALL_LOG%"\r\nexit /b 0\r\n',
+    posix: `#!/bin/sh\necho "npm $*" >> "$DSH_TEST_CALL_LOG"\nif [ "$1 $2 $3" = "config get registry" ]; then echo 'https://registry.npmjs.org/'; fi\nexit 0\n`,
+    windows:
+      '@echo off\r\necho npm %*>>"%DSH_TEST_CALL_LOG%"\r\nif "%~1 %~2 %~3"=="config get registry" echo https://registry.npmjs.org/\r\nexit /b 0\r\n',
   })
   await writeFixtureCommand(bin, 'ps', {
     posix: '#!/bin/sh\nexit 0\n',

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -30,7 +30,7 @@ test('公开 setup CLI 在一个进程内完成插件安装和配置', async (t)
   )
   await writeFile(
     path.join(bin, 'npm'),
-    `#!/bin/sh\necho "npm $*" >> "$DSH_TEST_CALL_LOG"\nif [ "$1" = "view" ]; then echo '"0.1.0"'; fi\nexit 0\n`,
+    `#!/bin/sh\necho "npm $*" >> "$DSH_TEST_CALL_LOG"\nif [ "$1 $2 $3" = "config get registry" ]; then echo 'https://registry.npmjs.org/'; fi\nexit 0\n`,
   )
   await writeFile(path.join(bin, 'pnpm'), `#!/bin/sh\necho "pnpm $*" >> "$DSH_TEST_CALL_LOG"\necho 11.7.0\nexit 0\n`)
   await writeFile(path.join(bin, 'ps'), '#!/bin/sh\necho "4242 1 node /tmp/dsh/lib/bin.js web"\n')
@@ -62,6 +62,11 @@ test('公开 setup CLI 在一个进程内完成插件安装和配置', async (t)
   assert.match(result.stdout, /\/bind [A-Z0-9]+/)
   assert.doesNotMatch(result.stdout, /secret-cli/)
   assert.match(await readFile(log, 'utf8'), /dsh plugin --profile web add/)
+  assert.match(await readFile(log, 'utf8'), /npm config get registry/)
+  assert.equal(
+    await readFile(path.join(root, '.dsh', 'profiles', 'web', '.npmrc'), 'utf8'),
+    'registry=https://registry.npmjs.org/\n',
+  )
   assert.match(result.stdout, /检测到 dsh web 正在运行/)
   assert.doesNotMatch(await readFile(log, 'utf8'), /dsh web/)
   assert.deepEqual(parse(await readFile(path.join(root, '.dsh', '.credentials.yaml'), 'utf8')), {

--- a/test/setup-flow.test.mjs
+++ b/test/setup-flow.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
-import { mkdtemp, readFile, stat } from 'node:fs/promises'
+import { readFileSync } from 'node:fs'
+import { mkdir, mkdtemp, readFile, stat, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
@@ -61,10 +62,31 @@ class FakeRunner {
     this.calls.push([command, ...args])
     if (command === 'dsh' && args[0] === '--version') return { code: 0, stdout: '0.1.0\n', stderr: '' }
     if (command === 'pnpm' && args[0] === '--version') return { code: 0, stdout: '11.7.0\n', stderr: '' }
+    if (command === 'npm' && args.join(' ') === 'config get registry') {
+      return { code: 0, stdout: 'https://registry.npmjs.org/\n', stderr: '' }
+    }
     if (command === 'npm' && args[0] === 'view') return { code: 0, stdout: '"0.1.0"\n', stderr: '' }
     if (command === 'dsh' && args[0] === 'plugin') return { code: 0, stdout: '', stderr: '' }
     if (command === 'dws') return { code: 1, stdout: '', stderr: 'not installed' }
     return { code: 1, stdout: '', stderr: 'unexpected command' }
+  }
+}
+
+class RegistryOverrideRunner extends FakeRunner {
+  constructor(dshHome) {
+    super()
+    this.dshHome = dshHome
+  }
+
+  run(command, args) {
+    if (command === 'npm' && args.join(' ') === 'config get registry') {
+      this.calls.push([command, ...args])
+      return { code: 0, stdout: 'https://build-user:private-secret@registry.npmmirror.com/\n', stderr: '' }
+    }
+    if (command === 'dsh' && args[0] === 'plugin') {
+      this.profileNpmrcAtInstall = readFileSync(path.join(this.dshHome, 'profiles', 'web', '.npmrc'), 'utf8')
+    }
+    return super.run(command, args)
   }
 }
 
@@ -203,6 +225,58 @@ test('setup 按实际 DSH 版本选择凭据文档格式', () => {
   assert.throws(() => credentialLayoutForDshVersion('not-a-version'), /无法识别 DSH 版本/)
 })
 
+test('setup 在插件安装前把当前 npm registry 同步到 web profile', async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-registry-'))
+  t.after(() => import('node:fs/promises').then((fs) => fs.rm(root, { recursive: true, force: true })))
+  const dshHome = path.join(root, '.dsh')
+  const profileDir = path.join(dshHome, 'profiles', 'web')
+  await mkdir(profileDir, { recursive: true })
+  await writeFile(
+    path.join(profileDir, '.npmrc'),
+    [
+      '# 保留企业源的 scoped 配置',
+      '@example:registry=https://packages.example.test/',
+      'registry=https://stale.example.test/',
+      'always-auth=true',
+      '',
+    ].join('\n'),
+  )
+  const runner = new RegistryOverrideRunner(dshHome)
+
+  const result = await runGuidedSetup({
+    ui: new FakeUi({
+      credentialMethod: 'manual',
+      clientId: 'ding-app',
+      clientSecret: 'test-only-secret',
+      startWeb: false,
+    }),
+    runner,
+    dshHome,
+    stateDir: path.join(root, '.dsh-dingtalk'),
+    installSpec: '@dingtalk-real-ai/dsh-dingtalk@0.6.0',
+  })
+
+  assert.equal(result.code, 0)
+  assert.equal(
+    runner.calls.findIndex((call) => call.join(' ') === 'npm config get registry') <
+      runner.calls.findIndex((call) => call[0] === 'dsh' && call[1] === 'plugin'),
+    true,
+  )
+  assert.equal(
+    runner.profileNpmrcAtInstall,
+    [
+      '# 保留企业源的 scoped 配置',
+      '@example:registry=https://packages.example.test/',
+      'always-auth=true',
+      'registry=https://registry.npmmirror.com/',
+      '',
+    ].join('\n'),
+  )
+  if (process.platform !== 'win32') {
+    assert.equal((await stat(path.join(profileDir, '.npmrc'))).mode & 0o777, 0o600)
+  }
+})
+
 test('插件安装失败时 loading 以失败态和完成态文案收尾', async (t) => {
   const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-plugin-loading-failure-'))
   t.after(() => import('node:fs/promises').then((fs) => fs.rm(root, { recursive: true, force: true })))
@@ -247,6 +321,8 @@ test('插件安装失败时提取 pnpm 根因并保留完整日志', async (t) =
   assert.match(displayed, /依赖：@deepseek-ai\/dsh-base@0\.1\.1-rc\.2/)
   assert.doesNotMatch(displayed, /private-secret/)
   assert.match(displayed, /建议：当前 registry 可能缺少该版本/)
+  assert.match(displayed, /npm_config_registry=<可用 registry> npx @dingtalk-real-ai\/dsh-dingtalk@latest setup/)
+  assert.match(displayed, /~\/\.dsh\/profiles\/web\/\.npmrc/)
   assert.doesNotMatch(displayed, /Progress: resolved/)
 
   const logPath = displayed.match(/完整日志：(.+)/)?.[1]

--- a/test/setup-flow.test.mjs
+++ b/test/setup-flow.test.mjs
@@ -337,12 +337,17 @@ test('插件安装失败时提取 pnpm 根因并保留完整日志', async (t) =
 
 test('安装失败按权限、网络和磁盘错误给出可执行建议', async (t) => {
   const cases = [
+    [
+      'npm error notarget No matching version found for @deepseek-ai/dsh-cmdline@^0.1.1-rc.2.',
+      /当前 registry 可能缺少该版本/,
+      'ETARGET',
+    ],
     ['npm error code EACCES\nnpm error permission denied', /检查 npm 全局目录和目标目录权限/],
     ['npm error code ENOTFOUND\nnpm error network registry unavailable', /检查网络、代理、DNS 和 registry 可达性/],
     ['npm error code ENOSPC\nnpm error no space left on device', /清理磁盘空间后重试/],
   ]
 
-  for (const [stderr, suggestion] of cases) {
+  for (const [stderr, suggestion, errorCode] of cases) {
     const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-categorized-diagnostic-'))
     t.after(() => import('node:fs/promises').then((fs) => fs.rm(root, { recursive: true, force: true })))
     const ui = new FakeUi()
@@ -355,7 +360,9 @@ test('安装失败按权限、网络和磁盘错误给出可执行建议', async
     })
 
     assert.equal(result.code, 1)
-    assert.match(ui.messages.join('\n'), suggestion)
+    const displayed = ui.messages.join('\n')
+    assert.match(displayed, suggestion)
+    if (errorCode) assert.match(displayed, new RegExp(`错误码：${errorCode}`))
   }
 })
 

--- a/test/setup-machine.test.mjs
+++ b/test/setup-machine.test.mjs
@@ -22,11 +22,13 @@ class FakeRunner {
     pnpmVersion = '11.7.0',
     installedPnpmVersion = '11.7.0',
     pluginFailure = '',
+    registry = 'https://registry.npmjs.org/',
   } = {}) {
     this.dshInstalled = dshInstalled
     this.pnpmVersion = pnpmVersion
     this.installedPnpmVersion = installedPnpmVersion
     this.pluginFailure = pluginFailure
+    this.registry = registry
   }
 
   run(command, args) {
@@ -43,6 +45,9 @@ class FakeRunner {
       return this.pluginFailure
         ? { code: 1, stdout: '', stderr: this.pluginFailure }
         : { code: 0, stdout: '', stderr: '' }
+    }
+    if (command === 'npm' && args.join(' ') === 'config get registry') {
+      return { code: 0, stdout: `${this.registry}\n`, stderr: '' }
     }
     if (command === 'npm' && args[0] === 'install') {
       if (args.at(-1) === '@deepseek-ai/dsh@latest') this.dshInstalled = true
@@ -154,8 +159,13 @@ test('机器 setup 只执行显式批准的步骤，并在私密凭据前安全�
   assert.equal(result.next?.kind, 'private_command')
   assert.match(result.next?.command ?? '', /^npx @dingtalk-real-ai\/dsh-dingtalk@0\.5\.2 setup --resume [0-9a-f-]+$/)
   assert.deepEqual(
-    runner.calls.filter((call) => call[0] === 'npm'),
+    runner.calls.filter((call) => call[0] === 'npm' && call[1] === 'install'),
     [],
+  )
+  assert.equal(
+    runner.calls.findIndex((call) => call.join(' ') === 'npm config get registry') <
+      runner.calls.findIndex((call) => call[0] === 'dsh' && call[1] === 'plugin'),
+    true,
   )
   assert.deepEqual(
     runner.calls.find((call) => call[0] === 'dsh' && call[1] === 'plugin'),
@@ -170,6 +180,10 @@ test('机器 setup 只执行显式批准的步骤，并在私密凭据前安全�
   const profile = await readFile(path.join(setupOptions.dshHome, 'profiles', 'web', 'cordis.patch.yml'), 'utf8')
   assert.match(profile, /id: default/)
   assert.match(profile, /enabled: true/)
+  assert.equal(
+    await readFile(path.join(setupOptions.dshHome, 'profiles', 'web', '.npmrc'), 'utf8'),
+    'registry=https://registry.npmjs.org/\n',
+  )
 })
 
 test('机器 setup 在必需批准缺失时不做任何安装或配置写入', async (t) => {


### PR DESCRIPTION
## 用户影响

企业私有 npm 源未完整同步 DSH 预发布子包时，setup 外层 npm 即使通过 npm_config_registry 切换到可用源，DSH 内部 pnpm 仍可能回落到用户级私有源并安装失败。

## 改动

- 在安装插件前读取当前有效 npm registry，并以 0600 原子同步到 web profile 的 .npmrc
- 交互式 setup 与 AI Native machine setup 共用同一 registry 同步逻辑，plan 保持严格只读
- 保留 scoped registry、认证和其他现有 .npmrc 配置，并移除 registry URL 内嵌凭据
- 将纯 notarget 归一为 ETARGET，与 ERR_PNPM_NO_MATCHING_VERSION 一起提供可执行的切源与 profile .npmrc 指引
- 在中英文 README 中补充企业私有 npm 源的前置说明和绕行命令

## 验证

- corepack pnpm run ci
- 168/168 tests passed
- secret scan、Prettier、TypeScript typecheck 与 NPM tarball 校验通过
- Standards/Spec 双轴复核无阻塞问题

## 已知边界

本 PR 不修改上游 DSH 的预发布依赖范围；正式版后的依赖策略收敛仍应由上游 DSH 处理。