### PR TITLE
feat(digital-employee): align real DWS channel protocol

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,7 +12,7 @@
 
 接入必须由 DWS `dingtalk-tag connect --channel dsh` 发起，并通过 stdin 幂等调用本包的 `digital-employee register`。注册后重新运行 `setup` 管理 operator、私聊 OpenDingTalkId 和群 openConversationId 白名单。`doctor` 会按员工显示能力、ready、订阅、最近事件/回复/审计和脱敏失败码。
 
-当前公开 DWS 尚须发布完整的安全回复、operator 私聊、审计和 capability 契约后才能做真实联合验收；缺少任一契约时该员工 fail-closed，不影响机器人或其他员工。详细接口、运行边界和发布门禁见 [数字员工 Channel 文档](docs/digital-employees.md)。业务 ack/replay/cursor 未完成前，本能力不承诺 exactly-once 或不丢消息。
+本分支已按 DWS 的 `dingtalk-tag channel capabilities/reply/operator-private`、统一 JSON envelope、真实 snake_case Event Consume 和本地必需审计协议对齐；仍须固定 DWS/DSH/DEAP 精确 SHA 做真实组织联合验收。缺少任一能力或本地审计不可写时该员工 fail-closed，不影响机器人或其他员工。详细接口和验收边界见 [数字员工 Channel 文档](docs/digital-employees.md)。业务 ack/replay/cursor 未完成前，本能力不承诺 exactly-once 或不丢消息。
 
 ## AI Native 安装（推荐）
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,6 +6,14 @@
 
 需要 Node.js `^22.19.0 || >=24.0.0`。机器人只在本机 `dsh web` 运行且网络在线时工作；电脑休眠、断网或进程退出后不会在云端继续执行。
 
+## 数字员工 Channel（文本 MVP）
+
+数字员工是与机器人平级的新 Channel：机器人仍可在不安装 DWS 的环境中工作；只有启用数字员工时才要求兼容 DWS companion runtime。DWS 负责 connect、授权码交换和 Profile 凭据，DSH 负责本地白名单、事件进程、Session、Queue、Agent、文本回复和诊断，DSH 不保存 Token、AuthCode 或 Client Secret。
+
+接入必须由 DWS `dingtalk-tag connect --channel dsh` 发起，并通过 stdin 幂等调用本包的 `digital-employee register`。注册后重新运行 `setup` 管理 operator、私聊 OpenDingTalkId 和群 openConversationId 白名单。`doctor` 会按员工显示能力、ready、订阅、最近事件/回复/审计和脱敏失败码。
+
+当前公开 DWS 尚须发布完整的安全回复、operator 私聊、审计和 capability 契约后才能做真实联合验收；缺少任一契约时该员工 fail-closed，不影响机器人或其他员工。详细接口、运行边界和发布门禁见 [数字员工 Channel 文档](docs/digital-employees.md)。业务 ack/replay/cursor 未完成前，本能力不承诺 exactly-once 或不丢消息。
+
 ## AI Native 安装（推荐）
 
 AI 可以读取安装计划、执行经过批准的非秘密步骤，并从 checkpoint 续跑；扫码链接、Client Secret 和 `/bind` 明文不会进入机器 JSON 或 checkpoint，而是交给你亲自操作的独立终端。
@@ -205,6 +213,10 @@ npx @dingtalk-real-ai/dsh-dingtalk@<version> doctor --json
 # 不发起网络请求
 npx @dingtalk-real-ai/dsh-dingtalk@<version> doctor --offline
 npx @dingtalk-real-ai/dsh-dingtalk@<version> doctor --offline --json
+
+# 仅供 DWS connect 通过 stdin 调用；不要手工传递 Token/AuthCode
+dsh-dingtalk digital-employee register --stdin --json
+dsh-dingtalk digital-employee unregister --agent-uuid <uuid> --json --yes
 ```
 
 `npx` 不会创建可长期使用的 `dsh-dingtalk` 命令。若希望使用该短命令，可执行一次可选的全局安装：

--- a/docs/acceptance-checklist.md
+++ b/docs/acceptance-checklist.md
@@ -34,3 +34,23 @@
 - [ ] `doctor` 按机器人输出，且每个机器人的结论与真实状态一致。
 
 验收记录只保存版本、commit、时间、平台和结果，不保存二维码、Secret 或聊天内容。
+
+## 数字员工联合验收（发布阻塞）
+
+- [ ] 固定 DSH、DWS、DEAP 精确 SHA、测试组织和数字员工。
+- [ ] 无 DWS 环境中机器人安装、升级、消息闭环和 doctor 基线不变。
+- [ ] 兼容 DWS 的 capability probe 同时确认 Event Consume、回复 stdin、operator 私聊 stdin 和审计 stdin。
+- [ ] `connect --channel dsh` 一次完成绑定、独立 Profile 凭据落盘和幂等 register；DSH 配置中没有 Token/AuthCode/Secret。
+- [ ] setup 确认 operator，并配置一个额外私聊身份和一个群会话。
+- [ ] 白名单内私聊进入 Agent；白名单外私聊静默拒绝且只有无正文审计。
+- [ ] 白名单群进入 Agent；非白名单群静默拒绝且只有无正文审计。
+- [ ] 一个事件只映射到一个 DSH Session、一次 Agent turn、一次文本引用回复和一条可查询审计链。
+- [ ] `deliveryStatus: unknown` 不自动重发；已发送 `openMessageId` 不回流为新任务。
+- [ ] 重启 DSH 后 Session 恢复，eventId 不重复执行，没有遗留等价订阅。
+- [ ] 两个数字员工的进程、Profile、白名单、状态目录、Session 和回复身份完全隔离。
+- [ ] DWS 缺失、协议不兼容、Profile 撤销、ready 超时、坏 NDJSON 和回复失败只隔离目标员工。
+- [ ] 远程审计不可用时目标员工不开始新任务，机器人和其他员工继续工作。
+- [ ] 进程列表、argv、环境、日志、配置、状态文件、快照和服务端审计均无凭据与聊天正文。
+- [ ] 状态目录权限为 `0700`，状态、ledger 和 Session binding 文件权限为 `0600`。
+- [ ] macOS/Linux CI、fake DWS 协议测试、`pnpm run ci` 和 NPM tarball smoke 全部通过。
+- [ ] DWS 未提供业务 ack/replay/cursor 时，发布说明只声明“可用 MVP”，不承诺 exactly-once 或不丢消息。

--- a/docs/digital-employees.md
+++ b/docs/digital-employees.md
@@ -1,0 +1,99 @@
+# DSH 数字员工 Channel
+
+数字员工是与现有机器人平级的独立 Channel。机器人模式不依赖 DWS；只有启用了 `digitalEmployees[]` 的员工才要求本机安装兼容 DWS。首期仅支持文本事件和文本引用回复，多员工从第一版开始隔离运行。
+
+> 发布门禁：DSH 侧协议与 fake DWS 验证已经固化，但真实联合验收必须等待 DWS 发布本文所列的完整 stdin 回复、operator 私聊、审计与能力探测契约。缺少任一能力时，该员工 fail-closed，机器人和其他员工不受影响。
+
+## 接入与配置
+
+DWS 是唯一创建和绑定入口：
+
+```text
+dws dingtalk-tag connect --agent-uuid <uuid> --channel dsh
+```
+
+DWS 完成授权码交换并将 Refresh Token 写入独立 Profile 后，通过 stdin 调用：
+
+```text
+dsh-dingtalk digital-employee register --stdin --json
+```
+
+注册文档固定为 `schemaVersion: 1`，包含 `agentUuid`、展示名、精确 `corpId:userId` Profile、当前用户的 `operatorOpenDingTalkId` 和 `protocolVersion: 1`。注册是加锁、原子、幂等的，只更新目标员工；任何 Token、AuthCode、Secret、可执行路径或未知字段都会被拒绝。
+
+注销必须显式确认：
+
+```text
+dsh-dingtalk digital-employee unregister --agent-uuid <uuid> --json --yes
+```
+
+注册后运行交互式 `setup`，选择“管理数字员工 operator 与白名单”。新员工默认只有 operator 可私聊，额外私聊白名单和群白名单均为空。配置只保存稳定身份和 Profile selector，不保存 DWS 凭据。
+
+## DWS/DSH 协议
+
+DSH 启动每个员工前先执行只读能力探测，要求 DWS 同时声明：
+
+- Event Consume；
+- 文本引用回复 stdin；
+- operator 私聊 stdin；
+- 审计上报 stdin；
+- `protocolVersion: 1`。
+
+事件进程固定使用参数数组启动，不经过 shell：
+
+```text
+dws --profile <corpId:userId> event consume
+  user_im_message_receive_o2o_all
+  user_im_message_receive_group_all
+  --flatten --format ndjson
+```
+
+DSH 同时排空 stdout/stderr，只有收到精确的 `[event] ready` 后才接受 NDJSON。事件 schema 为：
+
+```json
+{
+  "schemaVersion": 1,
+  "eventId": "stable-event-id",
+  "messageId": "open-message-id",
+  "conversationId": "open-conversation-id",
+  "conversationType": "direct",
+  "senderOpenDingTalkId": "stable-sender-id",
+  "senderName": "display-name",
+  "text": "message text",
+  "createdAt": "timestamp"
+}
+```
+
+回复、operator 私聊和审计正文只从 stdin 传入；正文不会进入 argv、环境变量、配置、日志、运行状态或测试快照。回复结果必须回传 `openMessageId`、`conversationId`、`deliveryStatus` 和原幂等键。`deliveryStatus: unknown` 不自动重发，避免重复消息。
+
+审计只包含员工、事件、Session、operator、操作类型、工具名、状态、时间、回复消息 ID 和 trace ID 等元数据。审计不可用时不开始新任务。
+
+## 本地运行与隔离
+
+- 单聊只接受 operator 或 `allowedDirectSenders`；群聊只接受 `allowedGroups`。
+- 未授权消息静默丢弃，只上报无正文的拒绝审计。
+- 敏感操作通过 operator 私聊的一次性确认码审批；白名单普通成员不能批准。
+- 会话键包含 `agentUuid + conversationId`；`chat-sender` 还包含发送者身份。
+- 每个员工拥有独立的进程、Queue、Session binding、事件 ledger、发送消息 ledger 和 `0700/0600` 状态目录。
+- 事件按 `eventId` 持久化去重；已发送 `openMessageId` 用于阻断回复回环。
+- 启动失败按 DWS `retryable=false/true/unknown` 执行 `0/2/1` 次重试。
+- 停止时先关闭 stdin，等待优雅退出，再发送 SIGTERM；正常路径不使用 SIGKILL。
+
+`tools.enabled` 只控制 DWS Agent 工具，不控制数字员工 Channel。
+
+## 诊断
+
+`doctor` 和 `doctor --json` 按员工输出：
+
+- `agentUuid`、精确 DWS Profile 和协议版本；
+- 白名单数量；
+- 能力探测、ready 和单聊/群聊订阅；
+- 最近事件、回复和远程审计是否被观察到；
+- 脱敏失败码。
+
+诊断不输出 operator、白名单具体身份、凭据或聊天正文。
+
+## 发布与验收边界
+
+联合验收使用固定 DSH/DWS/DEAP SHA，依次覆盖机器人无 DWS 基线、一次 connect、四类白名单消息、唯一 Session/回复/审计、重启恢复、双员工隔离和故障注入。完整步骤见 [验收清单](acceptance-checklist.md)。
+
+业务 ack/replay/cursor 未完成前只能声明“可用 MVP”，不能承诺 exactly-once 或不丢消息。AI Card、图片、文件、语音、互动卡片审批和无 DWS 运行模式均后置。

--- a/docs/digital-employees.md
+++ b/docs/digital-employees.md
@@ -2,7 +2,7 @@
 
 数字员工是与现有机器人平级的独立 Channel。机器人模式不依赖 DWS；只有启用了 `digitalEmployees[]` 的员工才要求本机安装兼容 DWS。首期仅支持文本事件和文本引用回复，多员工从第一版开始隔离运行。
 
-> 发布门禁：DSH 侧协议与 fake DWS 验证已经固化，但真实联合验收必须等待 DWS 发布本文所列的完整 stdin 回复、operator 私聊、审计与能力探测契约。缺少任一能力时，该员工 fail-closed，机器人和其他员工不受影响。
+> 发布门禁：DSH fake 已对齐 DWS 的真实 ready、snake_case 事件、统一 JSON envelope 与 Channel 命令路径。仍须固定 DWS/DSH/DEAP 精确 SHA 做真实组织联合验收；缺少任一能力或本地审计不可写时，该员工 fail-closed，机器人和其他员工不受影响。
 
 ## 接入与配置
 
@@ -35,7 +35,7 @@ DSH 启动每个员工前先执行只读能力探测，要求 DWS 同时声明�
 - Event Consume；
 - 文本引用回复 stdin；
 - operator 私聊 stdin；
-- 审计上报 stdin；
+- `auditMode=local_required`；
 - `protocolVersion: 1`。
 
 事件进程固定使用参数数组启动，不经过 shell：
@@ -47,25 +47,24 @@ dws --profile <corpId:userId> event consume
   --flatten --format ndjson
 ```
 
-DSH 同时排空 stdout/stderr，只有收到精确的 `[event] ready` 后才接受 NDJSON。事件 schema 为：
+DSH 同时排空 stdout/stderr，只有 ready 行匹配 `^\[event\] ready(?:\s|$)` 后才接受 NDJSON；允许 `event_count`、`bus_pid` 等后缀。`--flatten` 事件不要求额外 schemaVersion，直接消费真实 snake_case 字段：
 
 ```json
 {
-  "schemaVersion": 1,
-  "eventId": "stable-event-id",
-  "messageId": "open-message-id",
-  "conversationId": "open-conversation-id",
-  "conversationType": "direct",
-  "senderOpenDingTalkId": "stable-sender-id",
-  "senderName": "display-name",
-  "text": "message text",
-  "createdAt": "timestamp"
+  "type": "user_im_message_receive_o2o_all",
+  "event_id": "stable-event-id",
+  "message_id": "open-message-id",
+  "conversation_id": "open-conversation-id",
+  "sender_open_dingtalk_id": "stable-sender-id",
+  "sender": "display-name",
+  "content": "message text",
+  "event_time": "timestamp"
 }
 ```
 
-回复、operator 私聊和审计正文只从 stdin 传入；正文不会进入 argv、环境变量、配置、日志、运行状态或测试快照。回复结果必须回传 `openMessageId`、`conversationId`、`deliveryStatus` 和原幂等键。`deliveryStatus: unknown` 不自动重发，避免重复消息。
+回复和 operator 私聊固定调用 `dingtalk-tag channel reply/operator-private --stdin --format json`，并要求 DWS envelope `ok=true`，业务结果从 `data` 读取。正文不会进入 argv、环境变量、配置、日志、运行状态或测试快照。回复结果必须回传 `openMessageId`、`conversationId`、`deliveryStatus` 和原幂等键。`deliveryStatus: unknown` 不自动重发，避免重复消息。
 
-审计只包含员工、事件、Session、operator、操作类型、工具名、状态、时间、回复消息 ID 和 trace ID 等元数据。审计不可用时不开始新任务。
+审计由 DSH 按员工写入本地 JSONL，目录 `0700`、文件 `0600` 并加锁；只包含事件、Session、操作类型、工具名、状态、时间、回复消息 ID 和 trace ID 等元数据，不含消息正文。本地审计不可写时不开始新任务；未来远程转发只能是可选 best-effort 扩展。
 
 ## 本地运行与隔离
 
@@ -87,7 +86,7 @@ DSH 同时排空 stdout/stderr，只有收到精确的 `[event] ready` 后才接
 - `agentUuid`、精确 DWS Profile 和协议版本；
 - 白名单数量；
 - 能力探测、ready 和单聊/群聊订阅；
-- 最近事件、回复和远程审计是否被观察到；
+- 最近事件、回复和本地审计是否被观察到；
 - 脱敏失败码。
 
 诊断不输出 operator、白名单具体身份、凭据或聊天正文。

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -27,9 +27,11 @@ import {
 import { runGuidedSetup } from './setup.js'
 import {
   CredentialDshUpgradeRequiredError,
-  enabledWebProfileAccounts,
+  enabledConfiguredWebProfileAccounts,
   loadDingTalkAccountCredentials,
   loadWebProfileConfig,
+  registerDigitalEmployee,
+  unregisterDigitalEmployee,
 } from './setup-state.js'
 import { SystemRunner } from './system-runner.js'
 
@@ -61,6 +63,10 @@ function usage(): void {
       '                                      人工处理私密步骤，或机器续跑',
       '  dsh-dingtalk doctor [--offline] [--json]',
       '                                      执行只读诊断',
+      '  dsh-dingtalk digital-employee register --stdin --json',
+      '                                      从 DWS 幂等注册数字员工',
+      '  dsh-dingtalk digital-employee unregister --agent-uuid <uuid> --json --yes',
+      '                                      注销一个数字员工',
       '  dsh-dingtalk --version             显示版本',
       '',
       `首次安装推荐：npx ${packageName}@latest setup`,
@@ -95,6 +101,57 @@ function writeJson(value: unknown): void {
 
 function writeJsonError(code: string): void {
   writeJson({ schemaVersion: 1, kind: 'error', error: { code } })
+}
+
+async function readBoundedStdin(maxBytes = 64 * 1024): Promise<string> {
+  const chunks: Buffer[] = []
+  let bytes = 0
+  for await (const chunk of stdin) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+    bytes += buffer.length
+    if (bytes > maxBytes) throw new CliArgumentError('input_too_large')
+    chunks.push(buffer)
+  }
+  return Buffer.concat(chunks).toString('utf8')
+}
+
+async function digitalEmployee(args: string[]): Promise<number> {
+  const [subcommand, ...input] = args
+  const remaining = [...input]
+  try {
+    if (subcommand === 'register') {
+      const fromStdin = takeFlag(remaining, '--stdin')
+      const json = takeFlag(remaining, '--json')
+      if (!fromStdin || !json || remaining.length) throw new CliArgumentError('invalid_arguments')
+      let registration: unknown
+      try {
+        registration = JSON.parse(await readBoundedStdin())
+      } catch (error) {
+        throw new CliArgumentError(error instanceof CliArgumentError ? error.message : 'invalid_json')
+      }
+      const result = await registerDigitalEmployee(dshHome(), registration)
+      writeJson({ schemaVersion: 1, kind: 'digital_employee_registration', ...result })
+      return 0
+    }
+    if (subcommand === 'unregister') {
+      const agentUuid = takeValue(remaining, '--agent-uuid')
+      const json = takeFlag(remaining, '--json')
+      const yes = takeFlag(remaining, '--yes')
+      if (!agentUuid || !json || remaining.length) throw new CliArgumentError('invalid_arguments')
+      if (!yes) {
+        writeJsonError('confirmation_required')
+        return 2
+      }
+      const result = await unregisterDigitalEmployee(dshHome(), agentUuid)
+      writeJson({ schemaVersion: 1, kind: 'digital_employee_unregistration', ...result })
+      return result.status === 'not_found' ? 1 : 0
+    }
+    throw new CliArgumentError('invalid_arguments')
+  } catch (error) {
+    const code = error instanceof Error ? error.message : 'digital_employee_failed'
+    writeJsonError(code)
+    return error instanceof CliArgumentError || /^(invalid|unsupported|duplicate|sensitive|unknown)_/.test(code) ? 2 : 1
+  }
 }
 
 function machineOptions(): MachineSetupOptions {
@@ -142,9 +199,9 @@ async function doctor(args: string[]): Promise<number> {
 
   const profile = await loadWebProfileConfig(dshHome())
   const icons = { pass: '✅', warn: '⚠️', fail: '❌' } as const
-  const accounts = enabledWebProfileAccounts(profile)
-  if (!accounts.length) {
-    console.log('⚠️ 钉钉机器人：profile 中没有启用的钉钉机器人')
+  const accounts = await enabledConfiguredWebProfileAccounts(dshHome(), profile)
+  if (!accounts.length && !profile.digitalEmployees.some((employee) => employee.enabled)) {
+    console.log('⚠️ 钉钉机器人：profile 中没有启用的钉钉机器人；数字员工 Channel 也未启用')
     return 1
   }
   let failed = false
@@ -164,6 +221,22 @@ async function doctor(args: string[]): Promise<number> {
     if (accounts.length > 1) console.log(`\n[${account.id}]`)
     for (const check of checks) console.log(`${icons[check.status]} ${check.title}：${check.detail}`)
     if (checks.some((check) => check.status === 'fail')) failed = true
+  }
+  if (profile.digitalEmployees.some((employee) => employee.enabled)) {
+    const report = await collectDoctorReport({
+      mode: offline ? 'offline' : 'online',
+      dshHome: dshHome(),
+      stateDir: stateDir(),
+    })
+    for (const employee of report.digitalEmployees) {
+      console.log(`\n[数字员工 ${employee.agentUuid}]`)
+      console.log(`ℹ️ DWS Profile：${employee.dwsProfile}；协议版本：${employee.protocolVersion}`)
+      for (const check of employee.checks) {
+        const icon = check.status === 'pass' ? '✅' : check.status === 'fail' || check.status === 'error' ? '❌' : '⚠️'
+        console.log(`${icon} ${check.message}`)
+      }
+      if (employee.result === 'fail' || employee.result === 'error') failed = true
+    }
   }
   return failed ? 1 : 0
 }
@@ -303,6 +376,7 @@ async function main(): Promise<void> {
   const [command, ...args] = process.argv.slice(2)
   if (command === 'setup') process.exitCode = await setup(args)
   else if (command === 'doctor') process.exitCode = await doctor(args)
+  else if (command === 'digital-employee') process.exitCode = await digitalEmployee(args)
   else if (command === '--version' || command === '-V') console.log(packageVersion)
   else {
     usage()

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -8,12 +8,15 @@ import { randomUUID } from 'node:crypto'
 import type { HostAgent, HostAgentContext, HostAgentRegistry, ImageBlock, TextBlock } from './host.js'
 import { sessionId } from './host.js'
 import type { InboundMessage } from './stream.js'
-import type { Renderer } from './renderer.js'
 import type { JsonStore } from './jsonstore.js'
 import type { ModelOverride } from './commands.js'
 
 /** conversationId → sessionId, persisted so a restarted host resumes the same session. */
 export type Bindings = JsonStore<string>
+
+export interface TurnRenderer {
+  onInbound(sessionId: string, msg: InboundMessage): Promise<void>
+}
 
 export interface BridgeOptions {
   cwd: string
@@ -27,7 +30,7 @@ export interface BridgeOptions {
   /** Default agent-preset composition (tools); empty when the deployment has no roster. */
   compose(): Promise<{ agentPreset?: string; setup?: (agentCtx: HostAgentContext) => Promise<void> }>
   /** Refresh transport context for tools that wait on channel input. */
-  onAgentMessage(agent: HostAgent, msg: InboundMessage): void
+  onAgentMessage(agent: HostAgent, msg: InboundMessage): void | Promise<void>
   /** Resolve one inbound picture into a stored attachment block; null = degrade to text note. */
   resolveImage?(downloadCode: string, scopeKey: string): Promise<ImageBlock | null>
 }
@@ -35,15 +38,15 @@ export interface BridgeOptions {
 export class Bridge {
   constructor(
     private readonly agents: HostAgentRegistry,
-    private readonly renderer: Renderer,
+    private readonly renderer: TurnRenderer,
     private readonly bindings: Bindings,
     private readonly opts: BridgeOptions,
   ) {}
 
   /** Drive one message through its agent; resolves when the turn settles. */
-  async process(msg: InboundMessage, scopeKey: string): Promise<void> {
+  async process(msg: InboundMessage, scopeKey: string): Promise<string> {
     const agent = await this.agentFor(scopeKey)
-    this.opts.onAgentMessage(agent, msg)
+    await this.opts.onAgentMessage(agent, msg)
     const settled = this.renderer.onInbound(agent.id, msg)
     const content: Array<TextBlock | ImageBlock> = []
     const parts = msg.contentParts?.length
@@ -69,6 +72,7 @@ export class Bridge {
       source: { kind: 'user' },
     })
     await settled
+    return agent.id
   }
 
   private async agentFor(conversationId: string): Promise<HostAgent> {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -7,10 +7,10 @@ import { existsSync, statSync } from 'node:fs'
 import type { HostAgentRegistry } from './host.js'
 import { sessionId } from './host.js'
 import type { InboundMessage } from './stream.js'
-import type { Outbound } from './outbound.js'
 import type { Bindings } from './bridge.js'
 import type { JsonStore } from './jsonstore.js'
 import type { Queue } from './queue.js'
+import type { ReplySink } from './reply-sink.js'
 
 export interface ModelOverride {
   provider: string
@@ -19,7 +19,7 @@ export interface ModelOverride {
 
 export interface CommandDeps {
   agents: HostAgentRegistry
-  outbound: Outbound
+  outbound: Pick<ReplySink, 'sendMarkdown'>
   bindings: Bindings
   modelOverrides: JsonStore<ModelOverride>
   queue: Queue
@@ -107,7 +107,7 @@ export class Commands {
     this.pendingBusyChoice.delete(conversationId)
     const msg = pending.ctx.queuedMsg
     const reply = async (t: string): Promise<void> => {
-      await this.deps.outbound.sendMarkdown(msg.sessionWebhook, this.deps.markdownTitle, t)
+      await this.deps.outbound.sendMarkdown(msg, this.deps.markdownTitle, t)
     }
     if (pending.ctx.started()) {
       await reply('ℹ️ 前面的任务已经完成，你排队的那条正在处理中——无需打断或并入。')
@@ -126,7 +126,7 @@ export class Commands {
     const key = scopeKey ?? msg.conversationId
     const text = msg.text.trim()
     const reply = async (t: string): Promise<void> => {
-      await this.deps.outbound.sendMarkdown(msg.sessionWebhook, this.deps.markdownTitle, t)
+      await this.deps.outbound.sendMarkdown(msg, this.deps.markdownTitle, t)
     }
 
     // Queue-busy numeric choice (valid for 5 minutes after the notice).

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 /** Plugin configuration schema (schemastery-validated, editable from DSH config layers). */
 import Schema from '@deepseek-ai/schemastery'
-import type { GroupAccess, ImageMode, SenderAccess } from './setup-state.js'
+import type { DigitalEmployeeConfig, GroupAccess, ImageMode, SenderAccess } from './setup-state.js'
 
 export type ReplyMode = 'aicard' | 'markdown' | 'text'
 
@@ -21,6 +21,7 @@ export interface AccountConfig {
 
 export interface Config {
   accounts: AccountConfig[]
+  digitalEmployees: DigitalEmployeeConfig[]
   clientId: string
   clientSecret: string
   workspace: string
@@ -69,10 +70,25 @@ const AccountConfigSchema: Schema<AccountConfig> = Schema.object({
   sessionScope: Schema.union(['chat', 'chat-sender']).description('该机器人的群聊会话隔离粒度'),
 })
 
+const DigitalEmployeeConfigSchema: Schema<DigitalEmployeeConfig> = Schema.object({
+  agentUuid: Schema.string().required().description('DWS 返回的稳定数字员工 UUID'),
+  name: Schema.string().description('数字员工展示名'),
+  enabled: Schema.boolean().default(true).description('是否启动该数字员工 Channel'),
+  dwsProfile: Schema.string().required().description('精确的 DWS corpId:userId Profile selector'),
+  operatorOpenDingTalkId: Schema.string().required().description('唯一 operator 的 OpenDingTalkId'),
+  allowedDirectSenders: Schema.array(Schema.string()).default([]).description('允许私聊的 OpenDingTalkId'),
+  allowedGroups: Schema.array(Schema.string()).default([]).description('允许群聊的 openConversationId'),
+  sessionScope: Schema.union(['chat', 'chat-sender']).default('chat').description('群聊会话隔离粒度'),
+  protocolVersion: Schema.union([1]).default(1).description('DWS/DSH 数字员工协议版本；首期固定为 1'),
+})
+
 export const Config: Schema<Config> = Schema.object({
   accounts: Schema.array(AccountConfigSchema)
     .default([])
     .description('多机器人列表；为空时兼容读取下方旧版单机器人配置'),
+  digitalEmployees: Schema.array(DigitalEmployeeConfigSchema)
+    .default([])
+    .description('数字员工 Channel；为空时不要求安装 DWS，也不改变机器人行为'),
   clientId: Schema.string().default('').description('钉钉应用 clientId（AppKey）；留空则读环境变量 DINGTALK_CLIENT_ID'),
   clientSecret: Schema.string()
     .role('secret')

--- a/src/digital-employee-audit.ts
+++ b/src/digital-employee-audit.ts
@@ -1,0 +1,90 @@
+import { chmod, mkdir, open, stat, unlink } from 'node:fs/promises'
+import path from 'node:path'
+
+export interface DigitalEmployeeAuditFields {
+  eventId?: string
+  sessionId?: string
+  operationType: string
+  toolName?: string
+  status: string
+  replyMessageId?: string
+  traceId?: string
+}
+
+const LOCK_RETRY_MS = 10
+const LOCK_ATTEMPTS = 100
+const STALE_LOCK_MS = 30_000
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/** 员工级本地可靠审计。只记录元数据，不接受消息正文。 */
+export class LocalDigitalEmployeeAuditLog {
+  private chain = Promise.resolve()
+  private readonly directory: string
+  private readonly file: string
+  private readonly lockFile: string
+
+  constructor(stateDir: string, agentUuid: string) {
+    this.directory = path.join(stateDir, 'audit')
+    this.file = path.join(this.directory, `${agentUuid}.jsonl`)
+    this.lockFile = path.join(this.directory, `${agentUuid}.lock`)
+  }
+
+  audit(fields: DigitalEmployeeAuditFields): Promise<void> {
+    const operation = this.chain.then(
+      () => this.append(fields),
+      () => this.append(fields),
+    )
+    this.chain = operation
+    return operation
+  }
+
+  private async append(fields: DigitalEmployeeAuditFields): Promise<void> {
+    await mkdir(this.directory, { recursive: true, mode: 0o700 })
+    await chmod(this.directory, 0o700)
+    const lock = await this.acquireLock()
+    try {
+      const entry = {
+        timestamp: new Date().toISOString(),
+        ...(fields.eventId ? { eventId: fields.eventId } : {}),
+        ...(fields.sessionId ? { sessionId: fields.sessionId } : {}),
+        operationType: fields.operationType,
+        ...(fields.toolName ? { toolName: fields.toolName } : {}),
+        status: fields.status,
+        ...(fields.replyMessageId ? { replyMessageId: fields.replyMessageId } : {}),
+        ...(fields.traceId ? { traceId: fields.traceId } : {}),
+      }
+      const output = await open(this.file, 'a', 0o600)
+      try {
+        await output.writeFile(`${JSON.stringify(entry)}\n`, { encoding: 'utf8' })
+        await output.sync()
+        await output.chmod(0o600)
+      } finally {
+        await output.close()
+      }
+    } finally {
+      await lock.close()
+      await unlink(this.lockFile).catch(() => undefined)
+    }
+  }
+
+  private async acquireLock() {
+    for (let attempt = 0; attempt < LOCK_ATTEMPTS; attempt++) {
+      try {
+        return await open(this.lockFile, 'wx', 0o600)
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error
+        try {
+          const info = await stat(this.lockFile)
+          if (Date.now() - info.mtimeMs > STALE_LOCK_MS) await unlink(this.lockFile)
+        } catch (statError) {
+          if ((statError as NodeJS.ErrnoException).code !== 'ENOENT') throw statError
+        }
+        await delay(LOCK_RETRY_MS)
+      }
+    }
+    throw new Error('digital_employee_audit_lock_timeout')
+  }
+}

--- a/src/digital-employee-ledger.ts
+++ b/src/digital-employee-ledger.ts
@@ -1,0 +1,80 @@
+import { randomUUID } from 'node:crypto'
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+
+const LEDGER_LIMIT = 10_000
+
+interface LedgerData {
+  seenEvents: Record<string, number>
+  sentMessageIds: Record<string, number>
+}
+
+function isLedgerRecord(value: unknown): value is Record<string, number> {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    Object.entries(value).every(
+      ([key, timestamp]) =>
+        key.length > 0 && key.length <= 512 && typeof timestamp === 'number' && Number.isFinite(timestamp),
+    )
+  )
+}
+
+function trimLedger(record: Record<string, number>): Record<string, number> {
+  const entries = Object.entries(record)
+  if (entries.length <= LEDGER_LIMIT) return record
+  return Object.fromEntries(entries.sort((left, right) => right[1] - left[1]).slice(0, LEDGER_LIMIT))
+}
+
+export function atomicPrivateJsonWrite(file: string, value: unknown): void {
+  mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 })
+  const temporary = `${file}.tmp.${process.pid}.${randomUUID()}`
+  writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 })
+  chmodSync(temporary, 0o600)
+  renameSync(temporary, file)
+  chmodSync(file, 0o600)
+}
+
+/** 每个数字员工独立持久化事件去重与已发送消息 ID。 */
+export class DigitalEmployeeLedger {
+  private data: LedgerData = { seenEvents: {}, sentMessageIds: {} }
+
+  constructor(private readonly file: string) {
+    mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 })
+    if (existsSync(file)) {
+      try {
+        const parsed = JSON.parse(readFileSync(file, 'utf8')) as Partial<LedgerData>
+        if (!isLedgerRecord(parsed.seenEvents) || !isLedgerRecord(parsed.sentMessageIds))
+          throw new Error('invalid_ledger')
+        this.data = { seenEvents: parsed.seenEvents, sentMessageIds: parsed.sentMessageIds }
+      } catch {
+        throw new Error('digital_employee_ledger_corrupt')
+      }
+    }
+  }
+
+  hasEvent(eventId: string): boolean {
+    return this.data.seenEvents[eventId] !== undefined
+  }
+
+  hasSentMessage(messageId: string): boolean {
+    return this.data.sentMessageIds[messageId] !== undefined
+  }
+
+  markEvent(eventId: string): void {
+    this.data.seenEvents[eventId] = Date.now()
+    this.save()
+  }
+
+  markSentMessage(messageId: string): void {
+    this.data.sentMessageIds[messageId] = Date.now()
+    this.save()
+  }
+
+  private save(): void {
+    this.data.seenEvents = trimLedger(this.data.seenEvents)
+    this.data.sentMessageIds = trimLedger(this.data.sentMessageIds)
+    atomicPrivateJsonWrite(this.file, this.data)
+  }
+}

--- a/src/digital-employee-renderer.ts
+++ b/src/digital-employee-renderer.ts
@@ -1,0 +1,347 @@
+import { randomBytes } from 'node:crypto'
+import type {
+  HostAgentContext,
+  HostApprovalOutcome,
+  HostSession,
+  HostSessionEvent,
+  HostUserQuestionAnswer,
+  HostUserQuestionItem,
+  HostUserQuestionRequest,
+} from './host.js'
+import type { InboundMessage } from './stream.js'
+import type { DigitalEmployeeControlSink, DigitalEmployeeReplySink } from './digital-employee-reply-sink.js'
+import type { DigitalEmployeeEvent, DigitalEmployeeInbound } from './digital-employee-types.js'
+import { describeTurnError } from './errors.js'
+
+const EMPTY_MODEL_RESPONSE = '模型本次未产出正文，请稍后重试。'
+
+interface TurnState {
+  event: DigitalEmployeeEvent
+  finalParts: string[]
+  chunks: string[]
+  settle(): void
+  fail(error: unknown): void
+}
+
+export class DigitalEmployeeTextRenderer {
+  private readonly pendingEvents = new Map<string, DigitalEmployeeEvent>()
+  private readonly states = new Map<string, TurnState>()
+
+  constructor(
+    private readonly runtime: DigitalEmployeeReplySink,
+    private readonly log: (line: string) => void,
+  ) {}
+
+  accept(input: DigitalEmployeeInbound): void {
+    this.pendingEvents.set(input.message.msgId, input.event)
+  }
+
+  discard(messageId: string): void {
+    this.pendingEvents.delete(messageId)
+  }
+
+  onInbound(sessionId: string, msg: InboundMessage): Promise<void> {
+    const event = this.pendingEvents.get(msg.msgId)
+    this.pendingEvents.delete(msg.msgId)
+    if (!event) return Promise.reject(new Error('missing_digital_employee_reply_context'))
+    let settle!: () => void
+    let fail!: (error: unknown) => void
+    const settled = new Promise<void>((resolve, reject) => {
+      settle = resolve
+      fail = reject
+    })
+    this.states.set(sessionId, { event, finalParts: [], chunks: [], settle, fail })
+    return settled
+  }
+
+  onSessionEvent(session: HostSession, event: HostSessionEvent): void {
+    const state = this.states.get(session.id)
+    if (!state) return
+    if (event.type === 'assistant/chunk') {
+      const chunk = event.data?.chunk
+      if (chunk?.type === 'text-delta' && typeof chunk.text === 'string') state.chunks.push(chunk.text)
+      return
+    }
+    if (event.type === 'assistant/message') {
+      const blocks = event.data?.message?.content
+      if (!Array.isArray(blocks)) return
+      const text = blocks
+        .filter((block: any) => block?.type === 'text' && typeof block.text === 'string')
+        .map((block: any) => block.text)
+        .join('')
+      if (text.trim()) state.finalParts.push(text)
+      return
+    }
+    if (event.type === 'turn/end') void this.finalize(session.id, state, event.data?.reason)
+  }
+
+  private async finalize(sessionId: string, state: TurnState, reason: any): Promise<void> {
+    if (!this.states.delete(sessionId)) return
+    const kind = reason?.kind
+    if (kind === 'aborted') {
+      state.settle()
+      return
+    }
+    const failure = reason?.failure ?? reason?.error
+    const failureMessage = typeof failure === 'string' ? failure : failure?.message
+    const failureCode =
+      typeof failure === 'object' && failure !== null && failure.code !== undefined ? String(failure.code) : undefined
+    const errorText = kind === 'error' ? describeTurnError(failureMessage, failureCode).replace(/[*`>#]/g, '') : ''
+    const text =
+      [state.finalParts.join('\n\n').trim() || state.chunks.join('').trim(), errorText]
+        .filter(Boolean)
+        .join('\n\n')
+        .trim() || EMPTY_MODEL_RESPONSE
+    try {
+      await this.runtime.reply(state.event, sessionId, text)
+      state.settle()
+    } catch (error) {
+      this.log(`text reply failed (${error instanceof Error ? error.message : 'unknown'})`)
+      state.fail(error)
+    }
+  }
+}
+
+interface ApprovalState {
+  code: string
+  toolName: string
+  resolve(outcome: HostApprovalOutcome): void
+  timer: ReturnType<typeof setTimeout>
+}
+
+interface QuestionState {
+  event: DigitalEmployeeEvent
+  request: HostUserQuestionRequest
+  resolve(answer: HostUserQuestionAnswer): void
+  timer: ReturnType<typeof setTimeout>
+}
+
+/** 数字员工敏感操作只接受 connect 时 operator 的私聊确认。 */
+export class DigitalEmployeeApprovalManager {
+  private readonly sessionEvents = new Map<string, DigitalEmployeeEvent>()
+  private readonly approvals = new Map<string, ApprovalState>()
+  private readonly questions = new Map<string, QuestionState>()
+  private questionSequence = 0
+
+  constructor(
+    private readonly runtime: DigitalEmployeeControlSink,
+    private readonly operatorOpenDingTalkId: string,
+    private readonly timeoutMs: number,
+    private readonly log: (line: string) => void,
+  ) {}
+
+  bindSession(sessionId: string, event: DigitalEmployeeEvent): void {
+    this.sessionEvents.set(sessionId, event)
+  }
+
+  install(ctx: HostAgentContext): void {
+    ctx.on('user-questions/request', async (request, next) => {
+      const agent = request.agent ?? ctx.agent
+      const event = agent ? this.sessionEvents.get(agent.id) : undefined
+      if (!agent || !event || !request.questions.length) return next()
+      const answer = new Promise<HostUserQuestionAnswer>((resolve) => {
+        const timer = setTimeout(() => {
+          this.questions.delete(agent.id)
+          void next()
+            .then(resolve)
+            .catch(() => resolve({ answers: [] }))
+        }, this.timeoutMs)
+        this.questions.set(agent.id, { event, request, resolve, timer })
+      })
+      try {
+        this.questionSequence++
+        await this.runtime.reply(
+          event,
+          agent.id,
+          renderQuestions(request.questions),
+          `question_prompt_${this.questionSequence}`,
+        )
+      } catch (error) {
+        const pending = this.questions.get(agent.id)
+        if (pending) {
+          clearTimeout(pending.timer)
+          this.questions.delete(agent.id)
+          pending.resolve(await next())
+        }
+        this.log(`question delivery failed (${error instanceof Error ? error.message : 'unknown'})`)
+      }
+      return answer
+    })
+    ctx.on(
+      'approval/request',
+      async (request, next) => {
+        const event = this.sessionEvents.get(request.agent.id)
+        if (!event) return next()
+        const code = randomBytes(4).toString('hex').slice(0, 6).toUpperCase()
+        const outcome = new Promise<HostApprovalOutcome>((resolve) => {
+          const timer = setTimeout(() => {
+            this.approvals.delete(request.agent.id)
+            resolve('rejected')
+            void this.runtime
+              .audit({
+                eventId: event.eventId,
+                sessionId: request.agent.id,
+                operationType: 'approval_request',
+                toolName: request.toolName,
+                status: 'timeout',
+              })
+              .catch(() => undefined)
+          }, this.timeoutMs)
+          this.approvals.set(request.agent.id, { code, toolName: request.toolName, resolve, timer })
+        })
+        try {
+          const delivery = await this.runtime.operatorPrivate(
+            [
+              'DSH 数字员工请求敏感操作审批',
+              `工具：${request.toolName}`,
+              request.reason ? `原因：${request.reason}` : '',
+              `允许一次请回复：确认 ${code}`,
+              `拒绝请回复：拒绝 ${code}`,
+            ]
+              .filter(Boolean)
+              .join('\n'),
+            'approval_request',
+          )
+          await this.runtime.audit({
+            eventId: event.eventId,
+            sessionId: request.agent.id,
+            operationType: 'approval_request',
+            toolName: request.toolName,
+            status: delivery.deliveryStatus,
+            replyMessageId: delivery.openMessageId,
+          })
+        } catch (error) {
+          const pending = this.approvals.get(request.agent.id)
+          if (pending) {
+            clearTimeout(pending.timer)
+            this.approvals.delete(request.agent.id)
+            pending.resolve('unavailable')
+          }
+          this.log(`operator approval delivery failed (${error instanceof Error ? error.message : 'unknown'})`)
+        }
+        return outcome
+      },
+      { prepend: true },
+    )
+  }
+
+  async handleInbound(input: DigitalEmployeeInbound): Promise<boolean> {
+    if (input.event.conversationType === 'direct' && input.event.senderOpenDingTalkId === this.operatorOpenDingTalkId) {
+      const match = input.event.text.trim().match(/^(确认|拒绝)\s+([A-F0-9]{6})$/)
+      if (match) {
+        for (const [sessionId, approval] of this.approvals) {
+          if (approval.code !== match[2]) continue
+          clearTimeout(approval.timer)
+          this.approvals.delete(sessionId)
+          const approved = match[1] === '确认'
+          try {
+            await this.runtime.audit({
+              eventId: input.event.eventId,
+              sessionId,
+              operationType: 'approval_response',
+              toolName: approval.toolName,
+              status: approved ? 'allowed_once' : 'rejected',
+            })
+            approval.resolve(approved ? 'allowed-once' : 'rejected')
+          } catch {
+            approval.resolve('unavailable')
+          }
+          return true
+        }
+      }
+    }
+    for (const [sessionId, question] of this.questions) {
+      if (
+        input.event.conversationId !== question.event.conversationId ||
+        input.event.senderOpenDingTalkId !== question.event.senderOpenDingTalkId
+      ) {
+        continue
+      }
+      const answer = parseQuestionAnswer(question.request.questions, input.event.text)
+      if (!answer) return false
+      clearTimeout(question.timer)
+      this.questions.delete(sessionId)
+      question.resolve(answer)
+      return true
+    }
+    return false
+  }
+
+  expects(event: DigitalEmployeeEvent): boolean {
+    if (
+      event.conversationType === 'direct' &&
+      event.senderOpenDingTalkId === this.operatorOpenDingTalkId &&
+      /^(确认|拒绝)\s+[A-F0-9]{6}$/.test(event.text.trim()) &&
+      this.approvals.size > 0
+    ) {
+      return true
+    }
+    for (const question of this.questions.values()) {
+      if (
+        event.conversationId === question.event.conversationId &&
+        event.senderOpenDingTalkId === question.event.senderOpenDingTalkId
+      ) {
+        return true
+      }
+    }
+    return false
+  }
+}
+
+function renderQuestions(questions: readonly HostUserQuestionItem[]): string {
+  const lines = ['DSH 需要你补充信息：']
+  questions.forEach((question, index) => {
+    lines.push(`${index + 1}. ${question.header ? `[${question.header}] ` : ''}${question.question}`)
+    if (question.detail) lines.push(`   ${question.detail}`)
+    question.options?.forEach((option, optionIndex) => {
+      lines.push(`   ${optionIndex + 1}) ${option.label}${option.description ? ` — ${option.description}` : ''}`)
+    })
+  })
+  lines.push(
+    questions.length === 1
+      ? '请直接回复选项序号、选项文字或自定义答案。'
+      : '请逐行回复“题号=答案”，例如：1=1；2=自定义内容。',
+  )
+  return lines.join('\n')
+}
+
+function parseOneQuestion(question: HostUserQuestionItem, value: string): { selected: string[]; custom?: string } {
+  const raw = value.trim()
+  const values = question.multiSelect ? raw.split(/[，,]+/u).map((item) => item.trim()) : [raw]
+  const selected: string[] = []
+  const custom: string[] = []
+  for (const entry of values) {
+    const numeric = Number(entry)
+    const option = Number.isInteger(numeric) && numeric > 0 ? question.options?.[numeric - 1] : undefined
+    const exact = question.options?.find((item) => item.label === entry)
+    if (option || exact) selected.push((option ?? exact)!.label)
+    else if (entry) custom.push(entry)
+  }
+  return {
+    selected,
+    ...(custom.length ? { custom: custom.join(question.multiSelect ? '，' : '') } : {}),
+  }
+}
+
+function parseQuestionAnswer(
+  questions: readonly HostUserQuestionItem[],
+  text: string,
+): HostUserQuestionAnswer | undefined {
+  if (questions.length === 1) {
+    const answer = parseOneQuestion(questions[0], text)
+    if (!answer.selected.length && !answer.custom) return undefined
+    return { answers: [{ id: questions[0].id, ...answer }] }
+  }
+  const entries = new Map<number, string>()
+  for (const line of text.split(/\r?\n/u)) {
+    const match = line.trim().match(/^(\d+)\s*[=:：]\s*(.+)$/u)
+    if (match) entries.set(Number(match[1]), match[2])
+  }
+  if (entries.size !== questions.length) return undefined
+  return {
+    answers: questions.map((question, index) => ({
+      id: question.id,
+      ...parseOneQuestion(question, entries.get(index + 1) ?? ''),
+    })),
+  }
+}

--- a/src/digital-employee-reply-sink.ts
+++ b/src/digital-employee-reply-sink.ts
@@ -1,0 +1,283 @@
+import { createHash } from 'node:crypto'
+import { spawn } from 'node:child_process'
+import type { DigitalEmployeeLedger } from './digital-employee-ledger.js'
+import type { DigitalEmployeeConfig } from './setup-state.js'
+import type { DigitalEmployeeEvent, DigitalEmployeeReplyResult } from './digital-employee-types.js'
+
+const MAX_JSON_OUTPUT_BYTES = 256 * 1024
+
+interface DwsCapabilities {
+  schemaVersion: 1
+  protocolVersion: 1
+  capabilities: {
+    eventConsume: true
+    replyStdin: true
+    operatorPrivateStdin: true
+    auditStdin: true
+  }
+}
+
+export interface DigitalEmployeeAuditFields {
+  eventId?: string
+  sessionId?: string
+  operationType: string
+  toolName?: string
+  status: string
+  replyMessageId?: string
+  traceId?: string
+}
+
+export interface DigitalEmployeeReplySink {
+  reply(
+    event: DigitalEmployeeEvent,
+    sessionId: string,
+    text: string,
+    purpose?: string,
+  ): Promise<DigitalEmployeeReplyResult>
+  operatorPrivate(text: string, operationType: string): Promise<DigitalEmployeeReplyResult>
+}
+
+export interface DigitalEmployeeAuditSink {
+  audit(fields: DigitalEmployeeAuditFields): Promise<void>
+}
+
+export interface DigitalEmployeeControlSink extends DigitalEmployeeReplySink, DigitalEmployeeAuditSink {}
+
+interface DwsDigitalEmployeeReplySinkOptions {
+  employee: DigitalEmployeeConfig
+  dwsCommand?: string
+  ledger: DigitalEmployeeLedger
+  onFailure(code: string): void
+  onReply(): void
+  onAudit(): void
+}
+
+export function sanitizedDwsEnvironment(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const result = { ...env }
+  for (const key of Object.keys(result)) {
+    if (/(TOKEN|AUTH_?CODE|SECRET|PASSWORD|CREDENTIAL)/i.test(key)) delete result[key]
+  }
+  return result
+}
+
+function idempotencyKey(employee: DigitalEmployeeConfig, event: DigitalEmployeeEvent, operation: string): string {
+  return createHash('sha256').update(`${employee.agentUuid}\u0000${event.eventId}\u0000${operation}`).digest('hex')
+}
+
+/** DWS 的安全 stdin 回复、operator 私聊、审计与能力探测客户端。 */
+export class DwsDigitalEmployeeReplySink implements DigitalEmployeeControlSink {
+  private readonly pendingReplies = new Map<string, Set<Promise<unknown>>>()
+
+  constructor(private readonly options: DwsDigitalEmployeeReplySinkOptions) {}
+
+  async reply(
+    event: DigitalEmployeeEvent,
+    sessionId: string,
+    text: string,
+    purpose = 'reply',
+  ): Promise<DigitalEmployeeReplyResult> {
+    const key = idempotencyKey(this.options.employee, event, purpose)
+    let result: unknown
+    const delivery = this.execJson(
+      ['--profile', this.options.employee.dwsProfile, 'dingtalk-tag', 'reply', '--channel', 'dsh', '--stdin', '--json'],
+      {
+        schemaVersion: 1,
+        protocolVersion: 1,
+        agentUuid: this.options.employee.agentUuid,
+        eventId: event.eventId,
+        sessionId,
+        conversationId: event.conversationId,
+        referenceMessageId: event.messageId,
+        text,
+        idempotencyKey: key,
+      },
+    )
+    this.trackPendingReply(event.conversationId, delivery)
+    try {
+      result = await delivery
+    } catch (error) {
+      this.untrackPendingReply(event.conversationId, delivery)
+      this.options.onFailure('reply_failed')
+      throw error
+    }
+    const raw = result as Record<string, unknown>
+    if (
+      typeof raw.openMessageId !== 'string' ||
+      raw.conversationId !== event.conversationId ||
+      (raw.deliveryStatus !== 'delivered' && raw.deliveryStatus !== 'unknown') ||
+      raw.idempotencyKey !== key
+    ) {
+      this.untrackPendingReply(event.conversationId, delivery)
+      this.options.onFailure('invalid_reply_result')
+      throw new Error('invalid_reply_result')
+    }
+    this.options.ledger.markSentMessage(raw.openMessageId)
+    this.untrackPendingReply(event.conversationId, delivery)
+    this.options.onReply()
+    await this.audit({
+      eventId: event.eventId,
+      sessionId,
+      operationType: purpose,
+      status: raw.deliveryStatus,
+      replyMessageId: raw.openMessageId,
+    })
+    return raw as unknown as DigitalEmployeeReplyResult
+  }
+
+  async operatorPrivate(text: string, operationType: string): Promise<DigitalEmployeeReplyResult> {
+    const key = createHash('sha256')
+      .update(`${this.options.employee.agentUuid}\u0000${operationType}\u0000${Date.now()}`)
+      .digest('hex')
+    let result: unknown
+    try {
+      result = await this.execJson(
+        [
+          '--profile',
+          this.options.employee.dwsProfile,
+          'dingtalk-tag',
+          'operator-private',
+          '--channel',
+          'dsh',
+          '--stdin',
+          '--json',
+        ],
+        {
+          schemaVersion: 1,
+          protocolVersion: 1,
+          agentUuid: this.options.employee.agentUuid,
+          operatorOpenDingTalkId: this.options.employee.operatorOpenDingTalkId,
+          text,
+          idempotencyKey: key,
+        },
+      )
+    } catch (error) {
+      this.options.onFailure('operator_private_failed')
+      throw error
+    }
+    const raw = result as Record<string, unknown>
+    if (
+      typeof raw.openMessageId !== 'string' ||
+      typeof raw.conversationId !== 'string' ||
+      (raw.deliveryStatus !== 'delivered' && raw.deliveryStatus !== 'unknown') ||
+      raw.idempotencyKey !== key
+    ) {
+      this.options.onFailure('invalid_operator_reply_result')
+      throw new Error('invalid_operator_reply_result')
+    }
+    this.options.ledger.markSentMessage(raw.openMessageId)
+    return raw as unknown as DigitalEmployeeReplyResult
+  }
+
+  async audit(fields: DigitalEmployeeAuditFields): Promise<void> {
+    try {
+      await this.execJson(
+        [
+          '--profile',
+          this.options.employee.dwsProfile,
+          'dingtalk-tag',
+          'audit',
+          '--channel',
+          'dsh',
+          '--stdin',
+          '--json',
+        ],
+        {
+          schemaVersion: 1,
+          protocolVersion: 1,
+          agentUuid: this.options.employee.agentUuid,
+          operator: this.options.employee.operatorOpenDingTalkId,
+          time: new Date().toISOString(),
+          ...fields,
+        },
+      )
+    } catch (error) {
+      this.options.onFailure('audit_unavailable')
+      throw error
+    }
+    this.options.onAudit()
+  }
+
+  async probe(): Promise<void> {
+    let result: Partial<DwsCapabilities>
+    try {
+      result = (await this.execJson([
+        '--profile',
+        this.options.employee.dwsProfile,
+        'dingtalk-tag',
+        'capabilities',
+        '--channel',
+        'dsh',
+        '--json',
+      ])) as Partial<DwsCapabilities>
+    } catch (error) {
+      this.options.onFailure('dws_capability_probe_failed')
+      throw error
+    }
+    const capabilities = result.capabilities
+    if (
+      result.schemaVersion !== 1 ||
+      result.protocolVersion !== 1 ||
+      capabilities?.eventConsume !== true ||
+      capabilities.replyStdin !== true ||
+      capabilities.operatorPrivateStdin !== true ||
+      capabilities.auditStdin !== true
+    ) {
+      this.options.onFailure('incompatible_dws_capabilities')
+      throw new Error('incompatible_dws_capabilities')
+    }
+    await this.audit({ operationType: 'runtime_start', status: 'ready' })
+  }
+
+  async waitForPendingReplies(conversationId: string): Promise<void> {
+    const pending = [...(this.pendingReplies.get(conversationId) ?? [])]
+    if (pending.length) await Promise.allSettled(pending)
+  }
+
+  private trackPendingReply(conversationId: string, delivery: Promise<unknown>): void {
+    const pending = this.pendingReplies.get(conversationId) ?? new Set<Promise<unknown>>()
+    pending.add(delivery)
+    this.pendingReplies.set(conversationId, pending)
+  }
+
+  private untrackPendingReply(conversationId: string, delivery: Promise<unknown>): void {
+    const pending = this.pendingReplies.get(conversationId)
+    if (!pending) return
+    pending.delete(delivery)
+    if (!pending.size) this.pendingReplies.delete(conversationId)
+  }
+
+  private execJson(args: string[], input?: unknown): Promise<unknown> {
+    const command = this.options.dwsCommand ?? 'dws'
+    return new Promise((resolve, reject) => {
+      const child = spawn(command, args, {
+        shell: false,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: sanitizedDwsEnvironment(process.env),
+      })
+      let stdout = ''
+      let stderrBytes = 0
+      child.stdout.on('data', (chunk: Buffer) => {
+        stdout += chunk.toString('utf8')
+        if (Buffer.byteLength(stdout) > MAX_JSON_OUTPUT_BYTES) child.kill('SIGTERM')
+      })
+      child.stderr.on('data', (chunk: Buffer) => {
+        stderrBytes += chunk.length
+        if (stderrBytes > MAX_JSON_OUTPUT_BYTES) child.kill('SIGTERM')
+      })
+      child.once('error', () => reject(new Error('dws_spawn_failed')))
+      child.once('close', (code) => {
+        if (code !== 0) {
+          reject(new Error(`dws_exit_${code ?? 'unknown'}`))
+          return
+        }
+        try {
+          resolve(JSON.parse(stdout))
+        } catch {
+          reject(new Error('invalid_dws_json'))
+        }
+      })
+      if (input === undefined) child.stdin.end()
+      else child.stdin.end(`${JSON.stringify(input)}\n`)
+    })
+  }
+}

--- a/src/digital-employee-reply-sink.ts
+++ b/src/digital-employee-reply-sink.ts
@@ -107,6 +107,7 @@ export class DwsDigitalEmployeeReplySink implements DigitalEmployeeControlSink {
     const raw = result as Record<string, unknown>
     if (
       typeof raw.openMessageId !== 'string' ||
+      raw.openMessageId.trim() === '' ||
       raw.conversationId !== event.conversationId ||
       (raw.deliveryStatus !== 'delivered' && raw.deliveryStatus !== 'unknown') ||
       raw.idempotencyKey !== key
@@ -163,7 +164,9 @@ export class DwsDigitalEmployeeReplySink implements DigitalEmployeeControlSink {
     const raw = result as Record<string, unknown>
     if (
       typeof raw.openMessageId !== 'string' ||
+      raw.openMessageId.trim() === '' ||
       typeof raw.conversationId !== 'string' ||
+      raw.conversationId.trim() === '' ||
       (raw.deliveryStatus !== 'delivered' && raw.deliveryStatus !== 'unknown') ||
       raw.idempotencyKey !== key
     ) {

--- a/src/digital-employee-reply-sink.ts
+++ b/src/digital-employee-reply-sink.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto'
 import { spawn } from 'node:child_process'
+import type { DigitalEmployeeAuditFields } from './digital-employee-audit.js'
 import type { DigitalEmployeeLedger } from './digital-employee-ledger.js'
 import type { DigitalEmployeeConfig } from './setup-state.js'
 import type { DigitalEmployeeEvent, DigitalEmployeeReplyResult } from './digital-employee-types.js'
@@ -9,22 +10,12 @@ const MAX_JSON_OUTPUT_BYTES = 256 * 1024
 interface DwsCapabilities {
   schemaVersion: 1
   protocolVersion: 1
+  auditMode: 'local_required'
   capabilities: {
     eventConsume: true
     replyStdin: true
     operatorPrivateStdin: true
-    auditStdin: true
   }
-}
-
-export interface DigitalEmployeeAuditFields {
-  eventId?: string
-  sessionId?: string
-  operationType: string
-  toolName?: string
-  status: string
-  replyMessageId?: string
-  traceId?: string
 }
 
 export interface DigitalEmployeeReplySink {
@@ -47,6 +38,7 @@ interface DwsDigitalEmployeeReplySinkOptions {
   employee: DigitalEmployeeConfig
   dwsCommand?: string
   ledger: DigitalEmployeeLedger
+  auditSink: DigitalEmployeeAuditSink
   onFailure(code: string): void
   onReply(): void
   onAudit(): void
@@ -79,7 +71,18 @@ export class DwsDigitalEmployeeReplySink implements DigitalEmployeeControlSink {
     const key = idempotencyKey(this.options.employee, event, purpose)
     let result: unknown
     const delivery = this.execJson(
-      ['--profile', this.options.employee.dwsProfile, 'dingtalk-tag', 'reply', '--channel', 'dsh', '--stdin', '--json'],
+      [
+        '--profile',
+        this.options.employee.dwsProfile,
+        'dingtalk-tag',
+        'channel',
+        'reply',
+        '--channel',
+        'dsh',
+        '--stdin',
+        '--format',
+        'json',
+      ],
       {
         schemaVersion: 1,
         protocolVersion: 1,
@@ -135,11 +138,13 @@ export class DwsDigitalEmployeeReplySink implements DigitalEmployeeControlSink {
           '--profile',
           this.options.employee.dwsProfile,
           'dingtalk-tag',
+          'channel',
           'operator-private',
           '--channel',
           'dsh',
           '--stdin',
-          '--json',
+          '--format',
+          'json',
         ],
         {
           schemaVersion: 1,
@@ -170,26 +175,7 @@ export class DwsDigitalEmployeeReplySink implements DigitalEmployeeControlSink {
 
   async audit(fields: DigitalEmployeeAuditFields): Promise<void> {
     try {
-      await this.execJson(
-        [
-          '--profile',
-          this.options.employee.dwsProfile,
-          'dingtalk-tag',
-          'audit',
-          '--channel',
-          'dsh',
-          '--stdin',
-          '--json',
-        ],
-        {
-          schemaVersion: 1,
-          protocolVersion: 1,
-          agentUuid: this.options.employee.agentUuid,
-          operator: this.options.employee.operatorOpenDingTalkId,
-          time: new Date().toISOString(),
-          ...fields,
-        },
-      )
+      await this.options.auditSink.audit(fields)
     } catch (error) {
       this.options.onFailure('audit_unavailable')
       throw error
@@ -204,10 +190,12 @@ export class DwsDigitalEmployeeReplySink implements DigitalEmployeeControlSink {
         '--profile',
         this.options.employee.dwsProfile,
         'dingtalk-tag',
+        'channel',
         'capabilities',
         '--channel',
         'dsh',
-        '--json',
+        '--format',
+        'json',
       ])) as Partial<DwsCapabilities>
     } catch (error) {
       this.options.onFailure('dws_capability_probe_failed')
@@ -217,10 +205,10 @@ export class DwsDigitalEmployeeReplySink implements DigitalEmployeeControlSink {
     if (
       result.schemaVersion !== 1 ||
       result.protocolVersion !== 1 ||
+      result.auditMode !== 'local_required' ||
       capabilities?.eventConsume !== true ||
       capabilities.replyStdin !== true ||
-      capabilities.operatorPrivateStdin !== true ||
-      capabilities.auditStdin !== true
+      capabilities.operatorPrivateStdin !== true
     ) {
       this.options.onFailure('incompatible_dws_capabilities')
       throw new Error('incompatible_dws_capabilities')
@@ -271,7 +259,12 @@ export class DwsDigitalEmployeeReplySink implements DigitalEmployeeControlSink {
           return
         }
         try {
-          resolve(JSON.parse(stdout))
+          const envelope = JSON.parse(stdout) as Record<string, unknown>
+          if (envelope.ok !== true || envelope.outcome !== 'success' || !('data' in envelope)) {
+            reject(new Error('invalid_dws_envelope'))
+            return
+          }
+          resolve(envelope.data)
         } catch {
           reject(new Error('invalid_dws_json'))
         }

--- a/src/digital-employee-reply-sink.ts
+++ b/src/digital-employee-reply-sink.ts
@@ -37,6 +37,7 @@ export interface DigitalEmployeeControlSink extends DigitalEmployeeReplySink, Di
 interface DwsDigitalEmployeeReplySinkOptions {
   employee: DigitalEmployeeConfig
   dwsCommand?: string
+  dwsArgsPrefix?: readonly string[]
   ledger: DigitalEmployeeLedger
   auditSink: DigitalEmployeeAuditSink
   onFailure(code: string): void
@@ -236,8 +237,9 @@ export class DwsDigitalEmployeeReplySink implements DigitalEmployeeControlSink {
 
   private execJson(args: string[], input?: unknown): Promise<unknown> {
     const command = this.options.dwsCommand ?? 'dws'
+    const commandArgs = [...(this.options.dwsArgsPrefix ?? []), ...args]
     return new Promise((resolve, reject) => {
-      const child = spawn(command, args, {
+      const child = spawn(command, commandArgs, {
         shell: false,
         stdio: ['pipe', 'pipe', 'pipe'],
         env: sanitizedDwsEnvironment(process.env),

--- a/src/digital-employee-routing.ts
+++ b/src/digital-employee-routing.ts
@@ -1,0 +1,22 @@
+import { isSessionControl } from './commands.js'
+import type { DigitalEmployeeInbound } from './digital-employee-types.js'
+import type { InboundMessage } from './stream.js'
+
+interface DigitalEmployeeCommandRouter {
+  handle(message: InboundMessage, scopeKey?: string): Promise<boolean>
+}
+
+interface DigitalEmployeeInteractiveRouter {
+  handleInbound(input: DigitalEmployeeInbound): Promise<boolean>
+}
+
+/** 会话控制永远优先于待回答问题，避免 /new 和 /stop 被当成自由文本答案。 */
+export async function routeDigitalEmployeePreTask(
+  input: DigitalEmployeeInbound,
+  commands: DigitalEmployeeCommandRouter,
+  interactive: DigitalEmployeeInteractiveRouter,
+): Promise<boolean> {
+  if (isSessionControl(input.message.text) && (await commands.handle(input.message, input.scopeKey))) return true
+  if (await interactive.handleInbound(input)) return true
+  return commands.handle(input.message, input.scopeKey)
+}

--- a/src/digital-employee-runtime.ts
+++ b/src/digital-employee-runtime.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
 import { chmodSync, mkdirSync } from 'node:fs'
 import path from 'node:path'
+import { LocalDigitalEmployeeAuditLog } from './digital-employee-audit.js'
 import { atomicPrivateJsonWrite, DigitalEmployeeLedger } from './digital-employee-ledger.js'
 import { DwsDigitalEmployeeReplySink, sanitizedDwsEnvironment } from './digital-employee-reply-sink.js'
 import type { DigitalEmployeeEvent, DigitalEmployeeInbound } from './digital-employee-types.js'
@@ -14,7 +15,7 @@ export type {
   DigitalEmployeeReplyResult,
 } from './digital-employee-types.js'
 
-const READY_LINE = '[event] ready'
+const READY_LINE = /^\[event\] ready(?:\s|$)/
 const MAX_LINE_BYTES = 1024 * 1024
 const STATUS_HEARTBEAT_MS = 10_000
 
@@ -49,21 +50,26 @@ function safeId(value: unknown, field: string): string {
 function parseEvent(value: unknown): DigitalEmployeeEvent {
   if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('invalid_event')
   const raw = value as Record<string, unknown>
-  if (raw.schemaVersion !== 1) throw new Error('unsupported_event_schema')
-  if (raw.conversationType !== 'direct' && raw.conversationType !== 'group') {
-    throw new Error('invalid_conversation_type')
-  }
-  if (typeof raw.text !== 'string' || raw.text.length > MAX_LINE_BYTES) throw new Error('invalid_text')
+  const eventType = raw.type ?? raw.event_type
+  const conversationType =
+    eventType === 'user_im_message_receive_o2o_all'
+      ? 'direct'
+      : eventType === 'user_im_message_receive_group_all'
+        ? 'group'
+        : undefined
+  if (!conversationType) throw new Error('invalid_event_type')
+  if (typeof raw.content !== 'string' || raw.content.length > MAX_LINE_BYTES) throw new Error('invalid_text')
+  const createdAt = raw.create_time ?? raw.event_time ?? raw.timestamp
   return {
     schemaVersion: 1,
-    eventId: safeId(raw.eventId, 'event_id'),
-    messageId: safeId(raw.messageId, 'message_id'),
-    conversationId: safeId(raw.conversationId, 'conversation_id'),
-    conversationType: raw.conversationType,
-    senderOpenDingTalkId: safeId(raw.senderOpenDingTalkId, 'sender'),
-    senderName: typeof raw.senderName === 'string' ? raw.senderName.slice(0, 128) : '',
-    text: raw.text,
-    createdAt: typeof raw.createdAt === 'string' ? raw.createdAt : String(Date.now()),
+    eventId: safeId(raw.event_id, 'event_id'),
+    messageId: safeId(raw.message_id, 'message_id'),
+    conversationId: safeId(raw.conversation_id, 'conversation_id'),
+    conversationType,
+    senderOpenDingTalkId: safeId(raw.sender_open_dingtalk_id, 'sender'),
+    senderName: typeof raw.sender === 'string' ? raw.sender.slice(0, 128) : '',
+    text: raw.content,
+    createdAt: typeof createdAt === 'string' || typeof createdAt === 'number' ? String(createdAt) : String(Date.now()),
   }
 }
 
@@ -110,6 +116,8 @@ export class DwsDigitalEmployeeSource implements InboundSource {
   readonly replySink: DwsDigitalEmployeeReplySink
 
   constructor(private readonly options: DigitalEmployeeRuntimeOptions) {
+    mkdirSync(options.stateDir, { recursive: true, mode: 0o700 })
+    chmodSync(options.stateDir, 0o700)
     try {
       this.ledger = new DigitalEmployeeLedger(path.join(options.stateDir, 'ledger.json'))
     } catch {
@@ -122,12 +130,11 @@ export class DwsDigitalEmployeeSource implements InboundSource {
       employee: options.employee,
       dwsCommand: options.dwsCommand,
       ledger: this.ledger,
+      auditSink: new LocalDigitalEmployeeAuditLog(options.stateDir, options.employee.agentUuid),
       onFailure: (code) => this.fail(code),
       onReply: () => this.updateStatus({ ...this.status, state: 'ready', lastReplyAt: Date.now() }),
       onAudit: () => this.updateStatus({ ...this.status, lastAuditAt: Date.now() }),
     })
-    mkdirSync(options.stateDir, { recursive: true, mode: 0o700 })
-    chmodSync(options.stateDir, 0o700)
   }
 
   async start(): Promise<void> {
@@ -193,7 +200,7 @@ export class DwsDigitalEmployeeSource implements InboundSource {
     let retryable: boolean | undefined
     let readyTimedOut = false
     const consumeLine = (line: string, stream: 'stdout' | 'stderr') => {
-      if (line === READY_LINE) {
+      if (READY_LINE.test(line)) {
         ready = true
         this.updateStatus({ state: 'ready' })
         this.startHeartbeat()
@@ -313,7 +320,7 @@ export class DwsDigitalEmployeeSource implements InboundSource {
       this.ledger.markEvent(event.eventId)
       return
     }
-    // 远程审计不可用时不开始新任务。成功后才占用 eventId，允许上游重放暂时失败的事件。
+    // 本地审计不可写时不开始新任务。成功后才占用 eventId，允许上游重放暂时失败的事件。
     await this.replySink.audit({ eventId: event.eventId, operationType: 'access_check', status: 'accepted' })
     await this.replySink.waitForPendingReplies(event.conversationId)
     if (this.ledger.hasEvent(event.eventId) || this.ledger.hasSentMessage(event.messageId)) return

--- a/src/digital-employee-runtime.ts
+++ b/src/digital-employee-runtime.ts
@@ -34,6 +34,7 @@ export interface DigitalEmployeeRuntimeOptions {
   employee: DigitalEmployeeConfig
   stateDir: string
   dwsCommand?: string
+  dwsArgsPrefix?: readonly string[]
   readyTimeoutMs?: number
   log(line: string): void
   onMessage(input: DigitalEmployeeInbound): void | Promise<void>
@@ -129,6 +130,7 @@ export class DwsDigitalEmployeeSource implements InboundSource {
     this.replySink = new DwsDigitalEmployeeReplySink({
       employee: options.employee,
       dwsCommand: options.dwsCommand,
+      dwsArgsPrefix: options.dwsArgsPrefix,
       ledger: this.ledger,
       auditSink: new LocalDigitalEmployeeAuditLog(options.stateDir, options.employee.agentUuid),
       onFailure: (code) => this.fail(code),
@@ -178,6 +180,7 @@ export class DwsDigitalEmployeeSource implements InboundSource {
   private async startConsumer(): Promise<void> {
     const command = this.options.dwsCommand ?? 'dws'
     const args = [
+      ...(this.options.dwsArgsPrefix ?? []),
       '--profile',
       this.options.employee.dwsProfile,
       'event',

--- a/src/digital-employee-runtime.ts
+++ b/src/digital-employee-runtime.ts
@@ -1,0 +1,370 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { chmodSync, mkdirSync } from 'node:fs'
+import path from 'node:path'
+import { atomicPrivateJsonWrite, DigitalEmployeeLedger } from './digital-employee-ledger.js'
+import { DwsDigitalEmployeeReplySink, sanitizedDwsEnvironment } from './digital-employee-reply-sink.js'
+import type { DigitalEmployeeEvent, DigitalEmployeeInbound } from './digital-employee-types.js'
+import type { InboundSource } from './inbound-source.js'
+import type { DigitalEmployeeConfig } from './setup-state.js'
+import type { InboundMessage } from './stream.js'
+
+export type {
+  DigitalEmployeeEvent,
+  DigitalEmployeeInbound,
+  DigitalEmployeeReplyResult,
+} from './digital-employee-types.js'
+
+const READY_LINE = '[event] ready'
+const MAX_LINE_BYTES = 1024 * 1024
+const STATUS_HEARTBEAT_MS = 10_000
+
+export interface DigitalEmployeeRuntimeStatus {
+  state: 'probing' | 'connecting' | 'ready' | 'stopped' | 'failed'
+  observedAt: number
+  lastEventAt?: number
+  lastReplyAt?: number
+  lastAuditAt?: number
+  capabilitiesVerifiedAt?: number
+  subscriptionTopics?: string[]
+  failureCode?: string
+}
+
+export interface DigitalEmployeeRuntimeOptions {
+  employee: DigitalEmployeeConfig
+  stateDir: string
+  dwsCommand?: string
+  readyTimeoutMs?: number
+  log(line: string): void
+  onMessage(input: DigitalEmployeeInbound): void | Promise<void>
+  onStatus?(status: DigitalEmployeeRuntimeStatus): void
+}
+
+function safeId(value: unknown, field: string): string {
+  if (typeof value !== 'string' || !value || value.length > 512 || /[\u0000-\u001f]/.test(value)) {
+    throw new Error(`invalid_${field}`)
+  }
+  return value
+}
+
+function parseEvent(value: unknown): DigitalEmployeeEvent {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('invalid_event')
+  const raw = value as Record<string, unknown>
+  if (raw.schemaVersion !== 1) throw new Error('unsupported_event_schema')
+  if (raw.conversationType !== 'direct' && raw.conversationType !== 'group') {
+    throw new Error('invalid_conversation_type')
+  }
+  if (typeof raw.text !== 'string' || raw.text.length > MAX_LINE_BYTES) throw new Error('invalid_text')
+  return {
+    schemaVersion: 1,
+    eventId: safeId(raw.eventId, 'event_id'),
+    messageId: safeId(raw.messageId, 'message_id'),
+    conversationId: safeId(raw.conversationId, 'conversation_id'),
+    conversationType: raw.conversationType,
+    senderOpenDingTalkId: safeId(raw.senderOpenDingTalkId, 'sender'),
+    senderName: typeof raw.senderName === 'string' ? raw.senderName.slice(0, 128) : '',
+    text: raw.text,
+    createdAt: typeof raw.createdAt === 'string' ? raw.createdAt : String(Date.now()),
+  }
+}
+
+export function authorizeDigitalEmployeeEvent(employee: DigitalEmployeeConfig, event: DigitalEmployeeEvent): boolean {
+  if (event.conversationType === 'direct') {
+    return (
+      event.senderOpenDingTalkId === employee.operatorOpenDingTalkId ||
+      employee.allowedDirectSenders.includes(event.senderOpenDingTalkId)
+    )
+  }
+  return employee.allowedGroups.includes(event.conversationId)
+}
+
+function scopeKey(employee: DigitalEmployeeConfig, event: DigitalEmployeeEvent): string {
+  const chat = `${employee.agentUuid}:${event.conversationId}`
+  return employee.sessionScope === 'chat-sender' && event.conversationType === 'group'
+    ? `${chat}#${event.senderOpenDingTalkId}`
+    : chat
+}
+
+function normalizeInbound(event: DigitalEmployeeEvent): InboundMessage {
+  return {
+    msgId: event.messageId,
+    conversationId: event.conversationId,
+    conversationType: event.conversationType,
+    senderStaffId: event.senderOpenDingTalkId,
+    senderNick: event.senderName,
+    text: event.text,
+    createAt: event.createdAt,
+    sessionWebhook: '',
+  }
+}
+
+export class DwsDigitalEmployeeSource implements InboundSource {
+  private child?: ChildProcessWithoutNullStreams
+  private stopped = false
+  private status: DigitalEmployeeRuntimeStatus = { state: 'probing', observedAt: Date.now() }
+  private readonly ledger: DigitalEmployeeLedger
+  private eventChain = Promise.resolve()
+  private retryCount = 0
+  private restarting = false
+  private lastRetryable: boolean | undefined
+  private heartbeat?: ReturnType<typeof setInterval>
+  readonly replySink: DwsDigitalEmployeeReplySink
+
+  constructor(private readonly options: DigitalEmployeeRuntimeOptions) {
+    try {
+      this.ledger = new DigitalEmployeeLedger(path.join(options.stateDir, 'ledger.json'))
+    } catch {
+      this.status = { state: 'failed', observedAt: Date.now(), failureCode: 'ledger_corrupt' }
+      atomicPrivateJsonWrite(path.join(options.stateDir, 'runtime.json'), this.status)
+      options.onStatus?.({ ...this.status })
+      throw new Error('digital_employee_ledger_corrupt')
+    }
+    this.replySink = new DwsDigitalEmployeeReplySink({
+      employee: options.employee,
+      dwsCommand: options.dwsCommand,
+      ledger: this.ledger,
+      onFailure: (code) => this.fail(code),
+      onReply: () => this.updateStatus({ ...this.status, state: 'ready', lastReplyAt: Date.now() }),
+      onAudit: () => this.updateStatus({ ...this.status, lastAuditAt: Date.now() }),
+    })
+    mkdirSync(options.stateDir, { recursive: true, mode: 0o700 })
+    chmodSync(options.stateDir, 0o700)
+  }
+
+  async start(): Promise<void> {
+    try {
+      await this.probe()
+      if (this.stopped) return
+      this.updateStatus({ state: 'connecting' })
+      try {
+        await this.startConsumer()
+      } catch (error) {
+        if (!(await this.retryConsumer(this.lastRetryable))) throw error
+      }
+    } catch (error) {
+      if (!this.stopped && this.status.state !== 'failed') this.fail('digital_employee_start_failed')
+      throw error
+    }
+  }
+
+  async stop(): Promise<void> {
+    this.stopped = true
+    this.stopHeartbeat()
+    const child = this.child
+    this.child = undefined
+    if (child) await this.terminateChild(child)
+    this.updateStatus({ state: 'stopped' })
+  }
+
+  currentStatus(): DigitalEmployeeRuntimeStatus {
+    return { ...this.status }
+  }
+
+  private async probe(): Promise<void> {
+    await this.replySink.probe()
+    this.updateStatus({
+      ...this.status,
+      capabilitiesVerifiedAt: Date.now(),
+      subscriptionTopics: ['user_im_message_receive_o2o_all', 'user_im_message_receive_group_all'],
+    })
+  }
+
+  private async startConsumer(): Promise<void> {
+    const command = this.options.dwsCommand ?? 'dws'
+    const args = [
+      '--profile',
+      this.options.employee.dwsProfile,
+      'event',
+      'consume',
+      'user_im_message_receive_o2o_all',
+      'user_im_message_receive_group_all',
+      '--flatten',
+      '--format',
+      'ndjson',
+    ]
+    const child = spawn(command, args, {
+      shell: false,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: sanitizedDwsEnvironment(process.env),
+    })
+    this.child = child
+    let stdoutBuffer = ''
+    let stderrBuffer = ''
+    let ready = false
+    let retryable: boolean | undefined
+    let readyTimedOut = false
+    const consumeLine = (line: string, stream: 'stdout' | 'stderr') => {
+      if (line === READY_LINE) {
+        ready = true
+        this.updateStatus({ state: 'ready' })
+        this.startHeartbeat()
+        return
+      }
+      if (stream === 'stderr') {
+        if (/retryable\s*=\s*true/i.test(line)) retryable = true
+        if (/retryable\s*=\s*false/i.test(line)) retryable = false
+        return
+      }
+      if (!ready) throw new Error('event_before_ready')
+      if (Buffer.byteLength(line) > MAX_LINE_BYTES) throw new Error('event_line_too_large')
+      let value: unknown
+      try {
+        value = JSON.parse(line)
+      } catch {
+        this.options.log('event parse rejected (invalid_json)')
+        return
+      }
+      this.eventChain = this.eventChain
+        .then(() => this.handleEvent(parseEvent(value)))
+        .catch((error) => this.options.log(`event rejected (${error instanceof Error ? error.message : 'unknown'})`))
+    }
+    const drain = (chunk: Buffer, stream: 'stdout' | 'stderr') => {
+      let buffer = (stream === 'stdout' ? stdoutBuffer : stderrBuffer) + chunk.toString('utf8')
+      for (;;) {
+        const index = buffer.indexOf('\n')
+        if (index < 0) break
+        const line = buffer.slice(0, index).replace(/\r$/, '')
+        buffer = buffer.slice(index + 1)
+        try {
+          consumeLine(line, stream)
+        } catch (error) {
+          this.fail(error instanceof Error ? error.message : 'consume_failed')
+          child.stdin.end()
+          child.kill('SIGTERM')
+          break
+        }
+      }
+      if (Buffer.byteLength(buffer) > MAX_LINE_BYTES) {
+        this.fail('event_line_too_large')
+        child.stdin.end()
+        child.kill('SIGTERM')
+        buffer = ''
+      }
+      if (stream === 'stdout') stdoutBuffer = buffer
+      else stderrBuffer = buffer
+    }
+    child.stdout.on('data', (chunk: Buffer) => drain(chunk, 'stdout'))
+    child.stderr.on('data', (chunk: Buffer) => drain(chunk, 'stderr'))
+
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        readyTimedOut = true
+        this.lastRetryable = undefined
+        this.fail('ready_timeout_unknown')
+        void this.terminateChild(child)
+      }, this.options.readyTimeoutMs ?? 15_000)
+      const poll = setInterval(() => {
+        if (!ready) return
+        clearTimeout(timer)
+        clearInterval(poll)
+        resolve()
+      }, 5)
+      child.once('error', (error) => {
+        clearTimeout(timer)
+        clearInterval(poll)
+        this.lastRetryable = undefined
+        this.fail('dws_spawn_failed_unknown')
+        reject(error)
+      })
+      child.once('close', (code) => {
+        clearTimeout(timer)
+        clearInterval(poll)
+        this.lastRetryable = retryable
+        if (!this.stopped && !readyTimedOut) {
+          this.fail(`event_consumer_exit_${code ?? 'unknown'}_${retryable ?? 'unknown'}`)
+        }
+        if (!ready) reject(new Error(readyTimedOut ? 'ready_timeout' : 'event_consumer_exited_before_ready'))
+        else if (!this.stopped) void this.retryConsumer(retryable)
+      })
+    })
+  }
+
+  private retryBudget(retryable: boolean | undefined): number {
+    return retryable === false ? 0 : retryable === true ? 2 : 1
+  }
+
+  private async retryConsumer(retryable: boolean | undefined): Promise<boolean> {
+    if (this.restarting || this.stopped) return false
+    this.restarting = true
+    let hint = retryable
+    try {
+      for (;;) {
+        const budget = this.retryBudget(hint)
+        if (this.retryCount >= budget || this.stopped) return false
+        this.retryCount++
+        this.options.log(`event consumer retry ${this.retryCount}/${budget}`)
+        this.updateStatus({ state: 'connecting' })
+        try {
+          await this.startConsumer()
+          return true
+        } catch {
+          hint = this.lastRetryable
+        }
+      }
+    } finally {
+      this.restarting = false
+    }
+  }
+
+  private async handleEvent(event: DigitalEmployeeEvent): Promise<void> {
+    if (this.ledger.hasEvent(event.eventId) || this.ledger.hasSentMessage(event.messageId)) return
+    const allowed = authorizeDigitalEmployeeEvent(this.options.employee, event)
+    if (!allowed) {
+      await this.replySink.audit({ eventId: event.eventId, operationType: 'access_check', status: 'denied' })
+      this.ledger.markEvent(event.eventId)
+      return
+    }
+    // 远程审计不可用时不开始新任务。成功后才占用 eventId，允许上游重放暂时失败的事件。
+    await this.replySink.audit({ eventId: event.eventId, operationType: 'access_check', status: 'accepted' })
+    await this.replySink.waitForPendingReplies(event.conversationId)
+    if (this.ledger.hasEvent(event.eventId) || this.ledger.hasSentMessage(event.messageId)) return
+    if (this.status.state === 'failed') throw new Error('digital_employee_fail_closed')
+    this.ledger.markEvent(event.eventId)
+    this.updateStatus({ ...this.status, state: 'ready', lastEventAt: Date.now() })
+    void Promise.resolve(
+      this.options.onMessage({
+        event,
+        message: normalizeInbound(event),
+        scopeKey: scopeKey(this.options.employee, event),
+      }),
+    ).catch((error) => this.options.log(`task callback failed (${error instanceof Error ? error.message : 'unknown'})`))
+  }
+
+  private fail(code: string): void {
+    this.stopHeartbeat()
+    this.updateStatus({ ...this.status, state: 'failed', failureCode: code })
+  }
+
+  private async terminateChild(child: ChildProcessWithoutNullStreams): Promise<void> {
+    if (child.exitCode !== null) return
+    const closed = new Promise<void>((resolve) => child.once('close', () => resolve()))
+    child.stdin.end()
+    await Promise.race([closed, new Promise<void>((resolve) => setTimeout(resolve, 1_000))])
+    if (child.exitCode === null) {
+      child.kill('SIGTERM')
+      // 不使用 SIGKILL；等待确认旧订阅进程真实退出后才允许重试或完成 stop。
+      await closed
+    }
+  }
+
+  private startHeartbeat(): void {
+    this.stopHeartbeat()
+    this.heartbeat = setInterval(() => {
+      if (this.status.state === 'ready') this.updateStatus({ ...this.status, state: 'ready' })
+    }, STATUS_HEARTBEAT_MS)
+    this.heartbeat.unref()
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeat) clearInterval(this.heartbeat)
+    this.heartbeat = undefined
+  }
+
+  private updateStatus(next: Omit<DigitalEmployeeRuntimeStatus, 'observedAt'> & { observedAt?: number }): void {
+    this.status = { ...this.status, ...next, observedAt: next.observedAt ?? Date.now() }
+    if (next.state && next.state !== 'failed') delete this.status.failureCode
+    mkdirSync(this.options.stateDir, { recursive: true, mode: 0o700 })
+    const file = path.join(this.options.stateDir, 'runtime.json')
+    atomicPrivateJsonWrite(file, this.status)
+    this.options.onStatus?.({ ...this.status })
+  }
+}

--- a/src/digital-employee-runtime.ts
+++ b/src/digital-employee-runtime.ts
@@ -134,8 +134,8 @@ export class DwsDigitalEmployeeSource implements InboundSource {
       ledger: this.ledger,
       auditSink: new LocalDigitalEmployeeAuditLog(options.stateDir, options.employee.agentUuid),
       onFailure: (code) => this.fail(code),
-      onReply: () => this.updateStatus({ ...this.status, state: 'ready', lastReplyAt: Date.now() }),
-      onAudit: () => this.updateStatus({ ...this.status, lastAuditAt: Date.now() }),
+      onReply: () => this.updateStatus({ state: 'ready', lastReplyAt: Date.now() }),
+      onAudit: () => this.updateStatus({ lastAuditAt: Date.now() }),
     })
   }
 
@@ -171,7 +171,6 @@ export class DwsDigitalEmployeeSource implements InboundSource {
   private async probe(): Promise<void> {
     await this.replySink.probe()
     this.updateStatus({
-      ...this.status,
       capabilitiesVerifiedAt: Date.now(),
       subscriptionTopics: ['user_im_message_receive_o2o_all', 'user_im_message_receive_group_all'],
     })
@@ -329,7 +328,7 @@ export class DwsDigitalEmployeeSource implements InboundSource {
     if (this.ledger.hasEvent(event.eventId) || this.ledger.hasSentMessage(event.messageId)) return
     if (this.status.state === 'failed') throw new Error('digital_employee_fail_closed')
     this.ledger.markEvent(event.eventId)
-    this.updateStatus({ ...this.status, state: 'ready', lastEventAt: Date.now() })
+    this.updateStatus({ state: 'ready', lastEventAt: Date.now() })
     void Promise.resolve(
       this.options.onMessage({
         event,
@@ -341,7 +340,7 @@ export class DwsDigitalEmployeeSource implements InboundSource {
 
   private fail(code: string): void {
     this.stopHeartbeat()
-    this.updateStatus({ ...this.status, state: 'failed', failureCode: code })
+    this.updateStatus({ state: 'failed', failureCode: code })
   }
 
   private async terminateChild(child: ChildProcessWithoutNullStreams): Promise<void> {
@@ -359,7 +358,7 @@ export class DwsDigitalEmployeeSource implements InboundSource {
   private startHeartbeat(): void {
     this.stopHeartbeat()
     this.heartbeat = setInterval(() => {
-      if (this.status.state === 'ready') this.updateStatus({ ...this.status, state: 'ready' })
+      if (this.status.state === 'ready') this.updateStatus({ state: 'ready' })
     }, STATUS_HEARTBEAT_MS)
     this.heartbeat.unref()
   }
@@ -369,8 +368,8 @@ export class DwsDigitalEmployeeSource implements InboundSource {
     this.heartbeat = undefined
   }
 
-  private updateStatus(next: Omit<DigitalEmployeeRuntimeStatus, 'observedAt'> & { observedAt?: number }): void {
-    this.status = { ...this.status, ...next, observedAt: next.observedAt ?? Date.now() }
+  private updateStatus(next: Partial<Omit<DigitalEmployeeRuntimeStatus, 'observedAt'>>): void {
+    this.status = { ...this.status, ...next, observedAt: Date.now() }
     if (next.state && next.state !== 'failed') delete this.status.failureCode
     mkdirSync(this.options.stateDir, { recursive: true, mode: 0o700 })
     const file = path.join(this.options.stateDir, 'runtime.json')

--- a/src/digital-employee-types.ts
+++ b/src/digital-employee-types.ts
@@ -1,0 +1,26 @@
+import type { InboundMessage } from './stream.js'
+
+export interface DigitalEmployeeEvent {
+  schemaVersion: 1
+  eventId: string
+  messageId: string
+  conversationId: string
+  conversationType: 'direct' | 'group'
+  senderOpenDingTalkId: string
+  senderName: string
+  text: string
+  createdAt: string
+}
+
+export interface DigitalEmployeeInbound {
+  event: DigitalEmployeeEvent
+  message: InboundMessage
+  scopeKey: string
+}
+
+export interface DigitalEmployeeReplyResult {
+  openMessageId: string
+  conversationId: string
+  deliveryStatus: 'delivered' | 'unknown'
+  idempotencyKey: string
+}

--- a/src/doctor-report.ts
+++ b/src/doctor-report.ts
@@ -212,7 +212,7 @@ async function collectDigitalEmployeeReport(
       'digital-employee-capabilities',
       'digital-employee.capabilities-verified',
       'digital-employee.capabilities-unverified',
-      'DWS event/reply/operator-private/audit stdin 契约已通过运行时探测',
+      'DWS event/reply/operator-private 契约与本地必需审计已通过运行时探测',
       '尚未观察到兼容 DWS 能力探测结果',
     ),
   )
@@ -284,8 +284,8 @@ async function collectDigitalEmployeeReport(
       'digital-employee-audit',
       'digital-employee.audit-observed',
       'digital-employee.audit-unobserved',
-      '已观察到最近远程审计成功',
-      '尚未观察到远程审计成功',
+      '已观察到最近本地审计成功',
+      '尚未观察到本地审计成功',
     ),
   )
   return {

--- a/src/doctor-report.ts
+++ b/src/doctor-report.ts
@@ -1,3 +1,5 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { accountStateDir, DEFAULT_ACCOUNT_ID } from './accounts.js'
 import {
   collectDiagnostics,
@@ -5,13 +7,28 @@ import {
   type DiagnosticCheck,
   type DiagnosticCode,
 } from './diagnostics.js'
-import { enabledWebProfileAccounts, loadDingTalkAccountCredentials, loadWebProfileConfig } from './setup-state.js'
+import {
+  enabledConfiguredWebProfileAccounts,
+  loadDingTalkAccountCredentials,
+  loadWebProfileConfig,
+} from './setup-state.js'
 
 export type DoctorMode = 'online' | 'offline'
 export type DoctorResult = 'pass' | 'warning' | 'fail' | 'unverified' | 'error'
 
 export interface DoctorCheck {
-  id: DiagnosticCheck['id'] | 'profile' | 'diagnostics'
+  id:
+    | DiagnosticCheck['id']
+    | 'profile'
+    | 'diagnostics'
+    | 'digital-employee-config'
+    | 'digital-employee-whitelist'
+    | 'digital-employee-capabilities'
+    | 'digital-employee-runtime'
+    | 'digital-employee-subscription'
+    | 'digital-employee-event'
+    | 'digital-employee-reply'
+    | 'digital-employee-audit'
   status: DoctorResult
   code:
     | DiagnosticCode
@@ -19,6 +36,22 @@ export interface DoctorCheck {
     | 'profile.no-enabled-accounts'
     | 'credentials.read-error'
     | 'diagnostics.collect-error'
+    | 'digital-employee.configured'
+    | 'digital-employee.whitelist-configured'
+    | 'digital-employee.capabilities-verified'
+    | 'digital-employee.capabilities-unverified'
+    | 'digital-employee.ready'
+    | 'digital-employee.failed'
+    | 'digital-employee.unobserved'
+    | 'digital-employee.stale'
+    | 'digital-employee.subscription-ready'
+    | 'digital-employee.subscription-unverified'
+    | 'digital-employee.event-observed'
+    | 'digital-employee.event-unobserved'
+    | 'digital-employee.reply-observed'
+    | 'digital-employee.reply-unobserved'
+    | 'digital-employee.audit-observed'
+    | 'digital-employee.audit-unobserved'
   message: string
 }
 
@@ -37,6 +70,14 @@ export interface DoctorSummary {
   error: number
 }
 
+export interface DoctorDigitalEmployeeReport {
+  agentUuid: string
+  dwsProfile: string
+  protocolVersion: 1
+  result: DoctorResult
+  checks: DoctorCheck[]
+}
+
 export interface DoctorReport {
   schemaVersion: 1
   kind: 'doctor-report'
@@ -44,6 +85,7 @@ export interface DoctorReport {
   result: DoctorResult
   checks: DoctorCheck[]
   accounts: DoctorAccountReport[]
+  digitalEmployees: DoctorDigitalEmployeeReport[]
   summary: DoctorSummary
 }
 
@@ -76,6 +118,8 @@ const SAFE_DIAGNOSTICS: Record<DiagnosticCode, Pick<DoctorCheck, 'status' | 'mes
   'ai-card.unverified': { status: 'unverified', message: '尚未通过真实消息验证 AI Card 流式能力' },
 }
 
+const DIGITAL_EMPLOYEE_STATUS_FRESH_MS = 30_000
+
 function machineCheck(check: DiagnosticCheck): DoctorCheck {
   const safe = SAFE_DIAGNOSTICS[check.code]
   return { id: check.id, code: check.code, ...safe }
@@ -95,10 +139,162 @@ function reportResult(summary: DoctorSummary): DoctorResult {
   return 'pass'
 }
 
-function createReport(mode: DoctorMode, checks: DoctorCheck[], accounts: DoctorAccountReport[]): DoctorReport {
-  const allChecks = [...checks, ...accounts.flatMap((account) => account.checks)]
+function createReport(
+  mode: DoctorMode,
+  checks: DoctorCheck[],
+  accounts: DoctorAccountReport[],
+  digitalEmployees: DoctorDigitalEmployeeReport[] = [],
+): DoctorReport {
+  const allChecks = [
+    ...checks,
+    ...accounts.flatMap((account) => account.checks),
+    ...digitalEmployees.flatMap((employee) => employee.checks),
+  ]
   const summary = summarize(allChecks)
-  return { schemaVersion: 1, kind: 'doctor-report', mode, result: reportResult(summary), checks, accounts, summary }
+  return {
+    schemaVersion: 1,
+    kind: 'doctor-report',
+    mode,
+    result: reportResult(summary),
+    checks,
+    accounts,
+    digitalEmployees,
+    summary,
+  }
+}
+
+function observedCheck(
+  observed: boolean,
+  id: DoctorCheck['id'],
+  presentCode: DoctorCheck['code'],
+  absentCode: DoctorCheck['code'],
+  presentMessage: string,
+  absentMessage: string,
+): DoctorCheck {
+  return observed
+    ? { id, status: 'pass', code: presentCode, message: presentMessage }
+    : { id, status: 'unverified', code: absentCode, message: absentMessage }
+}
+
+async function collectDigitalEmployeeReport(
+  employee: Awaited<ReturnType<typeof loadWebProfileConfig>>['digitalEmployees'][number],
+  stateDir: string,
+): Promise<DoctorDigitalEmployeeReport> {
+  const checks: DoctorCheck[] = [
+    {
+      id: 'digital-employee-config',
+      status: 'pass',
+      code: 'digital-employee.configured',
+      message: '数字员工身份、精确 DWS Profile 和协议版本已配置',
+    },
+    {
+      id: 'digital-employee-whitelist',
+      status: 'pass',
+      code: 'digital-employee.whitelist-configured',
+      message: `operator 已配置；额外私聊白名单 ${employee.allowedDirectSenders.length} 人，群白名单 ${employee.allowedGroups.length} 个`,
+    },
+  ]
+  let runtime: Record<string, unknown> | undefined
+  try {
+    const value = JSON.parse(
+      await readFile(path.join(stateDir, 'digital-employees', employee.agentUuid, 'runtime.json'), 'utf8'),
+    )
+    if (value && typeof value === 'object' && !Array.isArray(value)) runtime = value as Record<string, unknown>
+  } catch {
+    // 未启动或状态文件不可读都只能标记为未验证，不猜测凭据或正文原因。
+  }
+  const observedAt = typeof runtime?.observedAt === 'number' ? runtime.observedAt : undefined
+  const age = observedAt === undefined ? undefined : Date.now() - observedAt
+  const runtimeFresh = age !== undefined && age >= 0 && age <= DIGITAL_EMPLOYEE_STATUS_FRESH_MS
+  checks.push(
+    observedCheck(
+      runtimeFresh && typeof runtime?.capabilitiesVerifiedAt === 'number',
+      'digital-employee-capabilities',
+      'digital-employee.capabilities-verified',
+      'digital-employee.capabilities-unverified',
+      'DWS event/reply/operator-private/audit stdin 契约已通过运行时探测',
+      '尚未观察到兼容 DWS 能力探测结果',
+    ),
+  )
+  if (runtime && !runtimeFresh) {
+    checks.push({
+      id: 'digital-employee-runtime',
+      status: 'unverified',
+      code: 'digital-employee.stale',
+      message: '数字员工运行状态记录已过期，不能据此判断进程仍存活',
+    })
+  } else if (runtime?.state === 'ready') {
+    checks.push({
+      id: 'digital-employee-runtime',
+      status: 'pass',
+      code: 'digital-employee.ready',
+      message: '数字员工事件进程已 ready',
+    })
+  } else if (runtime?.state === 'failed') {
+    const failureCode =
+      typeof runtime.failureCode === 'string' && /^[a-z0-9_.-]{1,128}$/i.test(runtime.failureCode)
+        ? runtime.failureCode
+        : 'unknown'
+    checks.push({
+      id: 'digital-employee-runtime',
+      status: 'fail',
+      code: 'digital-employee.failed',
+      message: `数字员工事件进程启动或运行失败（${failureCode}）`,
+    })
+  } else {
+    checks.push({
+      id: 'digital-employee-runtime',
+      status: 'unverified',
+      code: 'digital-employee.unobserved',
+      message: '尚未观察到数字员工事件进程 ready 状态',
+    })
+  }
+  const topics = Array.isArray(runtime?.subscriptionTopics) ? runtime.subscriptionTopics : []
+  const subscriptionsReady =
+    runtimeFresh &&
+    topics.includes('user_im_message_receive_o2o_all') &&
+    topics.includes('user_im_message_receive_group_all')
+  checks.push(
+    observedCheck(
+      subscriptionsReady,
+      'digital-employee-subscription',
+      'digital-employee.subscription-ready',
+      'digital-employee.subscription-unverified',
+      '单聊与群聊事件订阅均已就绪',
+      '尚未观察到完整的单聊与群聊订阅',
+    ),
+    observedCheck(
+      runtimeFresh && typeof runtime?.lastEventAt === 'number',
+      'digital-employee-event',
+      'digital-employee.event-observed',
+      'digital-employee.event-unobserved',
+      '已观察到最近事件（不展示正文）',
+      '尚未观察到事件',
+    ),
+    observedCheck(
+      runtimeFresh && typeof runtime?.lastReplyAt === 'number',
+      'digital-employee-reply',
+      'digital-employee.reply-observed',
+      'digital-employee.reply-unobserved',
+      '已观察到最近回复（不展示正文）',
+      '尚未观察到回复',
+    ),
+    observedCheck(
+      runtimeFresh && typeof runtime?.lastAuditAt === 'number',
+      'digital-employee-audit',
+      'digital-employee.audit-observed',
+      'digital-employee.audit-unobserved',
+      '已观察到最近远程审计成功',
+      '尚未观察到远程审计成功',
+    ),
+  )
+  return {
+    agentUuid: employee.agentUuid,
+    dwsProfile: employee.dwsProfile,
+    protocolVersion: 1,
+    result: reportResult(summarize(checks)),
+    checks,
+  }
 }
 
 /** 收集供自动化消费的完整诊断报告；所有 message 都来自固定脱敏文案。 */
@@ -115,8 +311,13 @@ export async function collectDoctorReport(options: DoctorReportOptions): Promise
     )
   }
 
-  const enabledAccounts = enabledWebProfileAccounts(profile)
-  if (!enabledAccounts.length) {
+  const enabledAccounts = await enabledConfiguredWebProfileAccounts(options.dshHome, profile)
+  const digitalEmployees = await Promise.all(
+    profile.digitalEmployees
+      .filter((employee) => employee.enabled)
+      .map((employee) => collectDigitalEmployeeReport(employee, options.stateDir)),
+  )
+  if (!enabledAccounts.length && !digitalEmployees.length) {
     return createReport(
       options.mode,
       [
@@ -166,5 +367,5 @@ export async function collectDoctorReport(options: DoctorReportOptions): Promise
     }
   }
 
-  return createReport(options.mode, [], accounts)
+  return createReport(options.mode, [], accounts, digitalEmployees)
 }

--- a/src/inbound-source.ts
+++ b/src/inbound-source.ts
@@ -1,0 +1,24 @@
+import { startStream, type StreamOptions } from './stream.js'
+
+/** 机器人与数字员工共同遵循的可托管入站源生命周期。 */
+export interface InboundSource {
+  start(): Promise<void>
+  stop(): void | Promise<void>
+}
+
+/** 保持现有 DingTalk Robot Stream 行为的生命周期适配器。 */
+export class RobotStreamSource implements InboundSource {
+  private dispose?: () => void
+
+  constructor(private readonly options: StreamOptions) {}
+
+  async start(): Promise<void> {
+    if (this.dispose) return
+    this.dispose = await startStream(this.options)
+  }
+
+  stop(): void {
+    this.dispose?.()
+    this.dispose = undefined
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,6 @@ import {
   type RuntimeAccount,
 } from './accounts.js'
 import { Config } from './config.js'
-import { startStream } from './stream.js'
 import { Outbound } from './outbound.js'
 import { Emotion } from './emotion.js'
 import { AICard, CardCapability, type CardTarget } from './aicard.js'
@@ -36,6 +35,12 @@ import { modelAcceptsImages } from './image-mode.js'
 import { exactPackageSpec } from './package-info.js'
 import { resolveStateDir } from './paths.js'
 import { cardTarget } from './targets.js'
+import { DwsDigitalEmployeeSource, type DigitalEmployeeInbound } from './digital-employee-runtime.js'
+import { DigitalEmployeeApprovalManager, DigitalEmployeeTextRenderer } from './digital-employee-renderer.js'
+import { routeDigitalEmployeePreTask } from './digital-employee-routing.js'
+import { BotReplySink } from './reply-sink.js'
+import { RobotStreamSource } from './inbound-source.js'
+import { validateDigitalEmployeeConfigs, type DigitalEmployeeConfig } from './setup-state.js'
 import type {
   HostAgentContext,
   HostAgentPresets,
@@ -69,7 +74,10 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
   for (const id of resolution.missingCredentialAccountIds) log(`robot ${id}: missing credentials — skipped`)
   for (const id of resolution.duplicateAccountIds)
     log(`robot ${id}: clientId already used by an earlier robot — skipped`)
-  if (!resolution.accounts.length) {
+  const digitalEmployees = validateDigitalEmployeeConfigs(config.digitalEmployees ?? []).filter(
+    (employee) => employee.enabled,
+  )
+  if (!resolution.accounts.length && !digitalEmployees.length) {
     log('no configured DingTalk robots could start')
     return
   }
@@ -77,24 +85,217 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
   const cwd = config.workspace || path.join(os.homedir(), 'dsh-dingtalk-workspace')
   fs.mkdirSync(cwd, { recursive: true })
   const primary = resolution.accounts[0]
-  const dwsTools = new DwsTools({
-    workspace: cwd,
-    clientId: primary.clientId,
-    clientSecret: primary.clientSecret,
-    exposeCredentials: resolution.accounts.length === 1,
-    log,
-  })
-  if (config.tools.enabled) void dwsTools.enable()
+  const dwsTools = primary
+    ? new DwsTools({
+        workspace: cwd,
+        clientId: primary.clientId,
+        clientSecret: primary.clientSecret,
+        exposeCredentials: resolution.accounts.length === 1,
+        log,
+      })
+    : undefined
+  if (config.tools.enabled && dwsTools) void dwsTools.enable()
 
-  await Promise.all(
-    resolution.accounts.map(async (account) => {
+  await Promise.all([
+    ...resolution.accounts.map(async (account) => {
       try {
         await startAccount(ctx, config, account, cwd, dwsTools)
       } catch (error) {
         log(`robot ${account.id}: failed to start (${error instanceof Error ? error.message : error})`)
       }
     }),
+    ...digitalEmployees.map(async (employee) => {
+      try {
+        await startDigitalEmployee(ctx, config, employee, cwd)
+      } catch (error) {
+        log(
+          `digital employee ${employee.agentUuid}: failed to start (${error instanceof Error ? error.message : error})`,
+        )
+      }
+    }),
+  ])
+}
+
+async function startDigitalEmployee(
+  ctx: Context,
+  config: Config,
+  employee: DigitalEmployeeConfig,
+  cwd: string,
+): Promise<void> {
+  const log = (line: string) =>
+    console.log(`[dsh-dingtalk:de:${employee.agentUuid} ${new Date().toTimeString().slice(0, 8)}] ${line}`)
+  const stateDir = path.join(resolveStateDir(), 'digital-employees', employee.agentUuid)
+  const agents = (ctx as any).agents as HostAgentRegistry
+  const defaultModel = (ctx as any).agentDefaultModel as HostDefaultModel
+  const currentDefault = () => {
+    try {
+      return defaultModel.currentSelection()
+    } catch (error) {
+      log(`default model unavailable (${error instanceof Error ? error.message : error})`)
+      return undefined
+    }
+  }
+  const workspace = new WorkspaceLinker({
+    cwd,
+    resolveRegistry: () => (ctx as any).get?.('workspaceRegistry'),
+    resolvePersistence: () => (ctx as any).get?.('sessionPersistence'),
+    log,
+  })
+  void workspace.start()
+  const bindings = new JsonStore<string>(path.join(stateDir, 'bindings.json'), log)
+  const modelOverrides = new JsonStore<ModelOverride>(path.join(stateDir, 'models.json'), log)
+  const workspaceOverrides = new JsonStore<string>(path.join(stateDir, 'workspaces.json'), log)
+  const queue = new Queue(log)
+  const eventsByMessageId = new Map<string, DigitalEmployeeInbound['event']>()
+  const commandReplyEvents = new Map<string, DigitalEmployeeInbound['event']>()
+  let commandSequence = 0
+  let bridge!: Bridge
+  let renderer!: DigitalEmployeeTextRenderer
+  let approvals!: DigitalEmployeeApprovalManager
+  let commands!: Commands
+
+  const runtime = new DwsDigitalEmployeeSource({
+    employee,
+    stateDir,
+    log,
+    onMessage: async (input) => {
+      commandReplyEvents.set(input.message.msgId, input.event)
+      try {
+        if (await routeDigitalEmployeePreTask(input, commands, approvals)) return
+      } finally {
+        commandReplyEvents.delete(input.message.msgId)
+      }
+      eventsByMessageId.set(input.message.msgId, input.event)
+      renderer.accept(input)
+      return queue.run(input.scopeKey, async () => {
+        try {
+          const sessionId = await bridge.process(input.message, input.scopeKey)
+          await replySink.audit({
+            eventId: input.event.eventId,
+            sessionId,
+            operationType: 'task_end',
+            status: 'completed',
+          })
+        } catch (error) {
+          eventsByMessageId.delete(input.message.msgId)
+          renderer.discard(input.message.msgId)
+          log(`task failed (${error instanceof Error ? error.message : 'unknown'})`)
+          try {
+            await replySink.audit({
+              eventId: input.event.eventId,
+              sessionId: bindings.get(input.scopeKey),
+              operationType: 'task_end',
+              status: 'failed',
+            })
+          } catch {
+            // 审计自身不可用时保持 fail-closed；不创建第二次模型任务或回复重试。
+          }
+        }
+      })
+    },
+  })
+  const replySink = runtime.replySink
+  renderer = new DigitalEmployeeTextRenderer(replySink, log)
+  approvals = new DigitalEmployeeApprovalManager(
+    replySink,
+    employee.operatorOpenDingTalkId,
+    config.approvalTimeoutMs,
+    log,
   )
+  commands = new Commands({
+    agents,
+    outbound: {
+      sendMarkdown: async (message, _title, text) => {
+        const event = commandReplyEvents.get(message.msgId)
+        if (!event) throw new Error('missing_digital_employee_command_reply_context')
+        commandSequence++
+        const result = await replySink.reply(
+          event,
+          `command:${event.eventId}`,
+          text,
+          `command_reply_${commandSequence}`,
+        )
+        return result.deliveryStatus === 'delivered'
+      },
+    },
+    bindings,
+    modelOverrides,
+    queue,
+    defaultModel: currentDefault,
+    toolsStatusLine: () => 'DWS Agent 工具与数字员工 Channel 独立',
+    workspaceOverrides,
+    defaultWorkspace: cwd,
+    listWorkspaces: async () => {
+      try {
+        const registry = (ctx as any).get?.('workspaceRegistry')
+        if (!registry?.list) return []
+        const items = await registry.list()
+        return (Array.isArray(items) ? items : []).map((item: any) => ({
+          path: item.path ?? String(item),
+          title: item.title,
+        }))
+      } catch {
+        return []
+      }
+    },
+    connectorStatus: () => {
+      const status = runtime.currentStatus()
+      return [
+        `Channel：数字员工文本模式（protocol 1）`,
+        `DWS Profile：${employee.dwsProfile}`,
+        `事件进程：${status.state}`,
+        `额外私聊白名单：${employee.allowedDirectSenders.length} 人`,
+        `群白名单：${employee.allowedGroups.length} 个`,
+        `远程审计：${status.lastAuditAt ? '最近成功' : '尚未观察到成功'}`,
+      ]
+    },
+    markdownTitle: config.markdownTitle,
+    log,
+  })
+  bridge = new Bridge(agents, renderer, bindings, {
+    cwd,
+    log,
+    modelOverrides,
+    workspaceOverrides,
+    modelSelection: currentDefault,
+    onAgentMessage: async (agent, msg) => {
+      const event = eventsByMessageId.get(msg.msgId)
+      eventsByMessageId.delete(msg.msgId)
+      if (event) {
+        approvals.bindSession(agent.id, event)
+        await replySink.audit({
+          eventId: event.eventId,
+          sessionId: agent.id,
+          operationType: 'task_start',
+          status: 'started',
+        })
+      }
+      void workspace.attach(agent.id)
+    },
+    compose: async () => {
+      const presets = (ctx as any).get?.('agentPresets') as HostAgentPresets | undefined
+      if (!presets) return { setup: async (agentCtx: HostAgentContext) => approvals.install(agentCtx) }
+      try {
+        const resolved = await presets.resolve(undefined)
+        return {
+          agentPreset: resolved.id,
+          setup: async (agentCtx: HostAgentContext) => {
+            await presets.mount(agentCtx, resolved.id)
+            approvals.install(agentCtx)
+          },
+        }
+      } catch (error) {
+        log(`preset compose failed (${error instanceof Error ? error.message : error})`)
+        return { setup: async (agentCtx: HostAgentContext) => approvals.install(agentCtx) }
+      }
+    },
+  })
+  ;(ctx as any).on('session/event', (session: HostSession, event: HostSessionEvent) => {
+    renderer.onSessionEvent(session, event)
+  })
+  ;(ctx as any).on('dispose', () => runtime.stop())
+  await runtime.start()
+  log(`channel up: profile=${employee.dwsProfile} protocol=1 text-only`)
 }
 
 async function startAccount(
@@ -102,7 +303,7 @@ async function startAccount(
   config: Config,
   account: RuntimeAccount,
   cwd: string,
-  dwsTools: DwsTools,
+  dwsTools: DwsTools | undefined,
 ): Promise<void> {
   const { clientId, clientSecret } = account
   const log = (line: string) =>
@@ -159,6 +360,7 @@ async function startAccount(
   }
 
   const outbound = new Outbound({ clientId, clientSecret }, log)
+  const replySink = new BotReplySink(outbound)
   // Shared by question/plan-review/approval cards and the queue busy card.
   const interactionCards = interactionCardTemplateId
     ? new InteractionCards(() => outbound.token(), clientId, interactionCardTemplateId, log)
@@ -182,7 +384,7 @@ async function startAccount(
   const emotion = new Emotion(() => outbound.token(), clientId, log)
   const renderer = new Renderer({
     config,
-    outbound,
+    outbound: replySink,
     emotion,
     createCard: (target: CardTarget) =>
       AICard.create({
@@ -199,7 +401,7 @@ async function startAccount(
   const workspaceOverrides = new JsonStore<string>(path.join(stateDir, 'workspaces.json'), log)
   const queue = new Queue(log)
   const questions = new QuestionManager({
-    outbound,
+    outbound: replySink,
     markdownTitle: config.markdownTitle,
     timeoutMs: config.questionTimeoutMs,
     approvalTimeoutMs: config.approvalTimeoutMs,
@@ -266,12 +468,12 @@ async function startAccount(
   })
   const commands = new Commands({
     agents,
-    outbound,
+    outbound: replySink,
     bindings,
     modelOverrides,
     queue,
     defaultModel: currentDefault,
-    toolsStatusLine: () => dwsTools.statusLine(),
+    toolsStatusLine: () => dwsTools?.statusLine() ?? 'DWS Agent 工具：未启用（不影响 Channel）',
     workspaceOverrides,
     defaultWorkspace: cwd,
     listWorkspaces: async () => {
@@ -347,7 +549,7 @@ async function startAccount(
       outbound.sendMarkdown(msg.sessionWebhook, config.markdownTitle, text),
     )
   }
-  const stop = await startStream({
+  const source = new RobotStreamSource({
     clientId,
     clientSecret,
     debug: config.debug,
@@ -522,7 +724,8 @@ async function startAccount(
       }
     },
   })
-  ;(ctx as any).on('dispose', () => stop())
+  await source.start()
+  ;(ctx as any).on('dispose', () => source.stop())
 
   log(
     `channel up: workspace=${cwd} replyMode=${config.replyMode.direct}/${config.replyMode.group} streaming=${config.streaming.enabled} async=${config.asyncMode}`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -246,7 +246,7 @@ async function startDigitalEmployee(
         `事件进程：${status.state}`,
         `额外私聊白名单：${employee.allowedDirectSenders.length} 人`,
         `群白名单：${employee.allowedGroups.length} 个`,
-        `远程审计：${status.lastAuditAt ? '最近成功' : '尚未观察到成功'}`,
+        `本地审计：${status.lastAuditAt ? '最近成功' : '尚未观察到成功'}`,
       ]
     },
     markdownTitle: config.markdownTitle,

--- a/src/jsonstore.ts
+++ b/src/jsonstore.ts
@@ -1,5 +1,6 @@
 /** Tiny persisted string-keyed map shared by bindings / model overrides. */
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { randomUUID } from 'node:crypto'
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
 import { dirname } from 'node:path'
 
 export class JsonStore<T> {
@@ -33,7 +34,11 @@ export class JsonStore<T> {
   }
 
   private save(): void {
-    mkdirSync(dirname(this.file), { recursive: true })
-    writeFileSync(this.file, JSON.stringify(Object.fromEntries(this.map), null, 2))
+    mkdirSync(dirname(this.file), { recursive: true, mode: 0o700 })
+    const temporary = `${this.file}.tmp.${process.pid}.${randomUUID()}`
+    writeFileSync(temporary, JSON.stringify(Object.fromEntries(this.map), null, 2), { mode: 0o600 })
+    chmodSync(temporary, 0o600)
+    renameSync(temporary, this.file)
+    chmodSync(this.file, 0o600)
   }
 }

--- a/src/questions.ts
+++ b/src/questions.ts
@@ -19,7 +19,7 @@ import type {
   HostUserQuestionRequest,
   SessionId,
 } from './host.js'
-import type { Outbound } from './outbound.js'
+import type { ReplySink } from './reply-sink.js'
 import type { InteractionCardCallback, InteractionCardRequest, InteractionCardSender } from './interaction-card.js'
 export type { InteractionCardCallback, InteractionCardRequest, InteractionCardSender } from './interaction-card.js'
 import type { InboundMessage } from './stream.js'
@@ -55,7 +55,7 @@ interface Route {
   conversationId: string
   conversationType: InboundMessage['conversationType']
   senderStaffId: string
-  sessionWebhook: string
+  replyContext: InboundMessage
 }
 
 interface PendingQuestion {
@@ -79,7 +79,7 @@ interface PendingApproval {
 
 /** One callback emitted by DingTalk's interactive-card Stream topic. */
 export interface QuestionManagerOptions {
-  outbound: Pick<Outbound, 'sendMarkdown'>
+  outbound: Pick<ReplySink, 'sendMarkdown'>
   markdownTitle: string
   timeoutMs: number
   approvalTimeoutMs?: number
@@ -235,7 +235,7 @@ export class QuestionManager {
       conversationId: msg.conversationId,
       conversationType: msg.conversationType,
       senderStaffId: msg.senderStaffId,
-      sessionWebhook: msg.sessionWebhook,
+      replyContext: msg,
     })
   }
 
@@ -276,7 +276,7 @@ export class QuestionManager {
     if (approval) {
       const route = this.routes.get(approval.sessionId)
       if (route) {
-        this.routes.set(approval.sessionId, { ...route, sessionWebhook: msg.sessionWebhook })
+        this.routes.set(approval.sessionId, { ...route, replyContext: msg })
       }
       const answer = normalized(msg.text)
       const code = normalized(approval.confirmationCode)
@@ -293,7 +293,7 @@ export class QuestionManager {
         return true
       }
       void this.opts.outbound.sendMarkdown(
-        msg.sessionWebhook,
+        msg,
         this.opts.markdownTitle,
         `审批仍在等待：请回复 \`确认 ${approval.confirmationCode}\` 或 \`拒绝 ${approval.confirmationCode}\`。`,
       )
@@ -404,7 +404,7 @@ export class QuestionManager {
     const approvalUserId = this.opts.approvalUserId?.() || route.senderStaffId
     if (route.conversationType === 'direct' && approvalUserId !== route.senderStaffId) {
       await this.opts.outbound.sendMarkdown(
-        route.sessionWebhook,
+        route.replyContext,
         this.opts.markdownTitle,
         '敏感操作只能由机器人管理员批准。当前是其他成员私聊，操作已拒绝；请让管理员在自己的私聊或已允许的群聊中发起。',
       )
@@ -447,7 +447,7 @@ export class QuestionManager {
         pending.cleanup()
         resolve('unavailable')
         void this.opts.outbound.sendMarkdown(
-          (this.routes.get(agent.id) ?? route).sessionWebhook,
+          (this.routes.get(agent.id) ?? route).replyContext,
           this.opts.markdownTitle,
           '敏感操作审批已超时，操作已拒绝。',
         )
@@ -480,7 +480,7 @@ export class QuestionManager {
         this.opts.interactionCards.create({
           outTrackId,
           kind: 'approval',
-          target: cardTarget(route),
+          target: cardTarget(route.replyContext),
           title: `批准 ${request.toolName}？`,
           detail: request.reason ?? `DSH 请求执行敏感工具：${request.toolName}`,
           approveLabel: '允许一次',
@@ -498,7 +498,7 @@ export class QuestionManager {
     const detail = request.reason?.trim() || `DSH 请求执行敏感工具：${request.toolName}`
     const attempt = await raceDelivery(
       this.opts.outbound.sendMarkdown(
-        route.sessionWebhook,
+        route.replyContext,
         this.opts.markdownTitle,
         [
           '### 审批敏感操作',
@@ -579,7 +579,7 @@ export class QuestionManager {
         this.opts.log(`ask_user_question timed out for session ${agent.id}`)
         const latest = this.routes.get(agent.id) ?? route
         void this.opts.outbound.sendMarkdown(
-          latest.sessionWebhook,
+          latest.replyContext,
           this.opts.markdownTitle,
           '等待回答已超时，本次问题已取消。',
         )
@@ -600,7 +600,7 @@ export class QuestionManager {
         delivered = await this.opts.interactionCards.create({
           outTrackId: cardId,
           kind: planApprove ? 'plan-review' : 'question',
-          target: cardTarget(route),
+          target: cardTarget(route.replyContext),
           title: question.header?.trim() || (planApprove ? 'Plan Review' : '请选择'),
           detail: question.detail?.trim() || question.question,
           approveLabel,
@@ -609,7 +609,7 @@ export class QuestionManager {
       }
       if (!delivered) {
         delivered = await this.opts.outbound.sendMarkdown(
-          route.sessionWebhook,
+          route.replyContext,
           this.opts.markdownTitle,
           renderQuestion(question, index, total),
         )

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -35,7 +35,7 @@ export class Queue {
    * Enqueue a task for the conversation. `onBusy(position)` fires immediately
    * when earlier work is still pending.
    */
-  run(key: string, task: () => Promise<void>, onBusy?: (position: number) => void): void {
+  run(key: string, task: () => Promise<void>, onBusy?: (position: number) => void): Promise<void> {
     const now = Date.now()
     for (const [k, e] of this.entries) {
       if (e.depth === 0 && now - e.settledAt > CLEANUP_AFTER_MS) this.entries.delete(k)
@@ -78,5 +78,6 @@ export class Queue {
       }
     }
     entry.tail = entry.tail.then(guarded)
+    return entry.tail
   }
 }

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -9,8 +9,8 @@
 import type { Config, ReplyMode } from './config.js'
 import type { HostSession, HostSessionEvent } from './host.js'
 import type { InboundMessage } from './stream.js'
-import type { Outbound } from './outbound.js'
 import type { Emotion } from './emotion.js'
+import type { ReplySink } from './reply-sink.js'
 import { AICard, CardCapabilityError, type CardTarget } from './aicard.js'
 import { cardTarget } from './targets.js'
 import { describeTurnError } from './errors.js'
@@ -76,7 +76,7 @@ function renderLive(segments: Segment[]): string {
 
 export interface RendererDeps {
   config: Pick<Config, 'replyMode' | 'streaming' | 'asyncMode' | 'ackText' | 'markdownTitle' | 'emotionFirstResponse'>
-  outbound: Outbound
+  outbound: ReplySink
   emotion: Emotion
   createCard(target: CardTarget): Promise<AICard | null>
   log(line: string): void
@@ -118,7 +118,7 @@ export class Renderer {
 
     if (config.asyncMode) {
       // Ack now; the settled result is pushed at turn end, no streaming card.
-      void this.deps.outbound.sendText(msg.sessionWebhook, config.ackText)
+      void this.deps.outbound.sendText(msg, config.ackText)
     } else if (mode === 'aicard') {
       state.cardPromise = this.deps.createCard(cardTarget(msg))
     }
@@ -311,7 +311,7 @@ export class Renderer {
       }
     }
     // markdown / text / asyncMode / card-fallback all land here.
-    if (st.mode === 'text' && !errText) await outbound.sendText(st.msg.sessionWebhook, text)
-    else await outbound.sendMarkdown(st.msg.sessionWebhook, config.markdownTitle, text)
+    if (st.mode === 'text' && !errText) await outbound.sendText(st.msg, text)
+    else await outbound.sendMarkdown(st.msg, config.markdownTitle, text)
   }
 }

--- a/src/reply-sink.ts
+++ b/src/reply-sink.ts
@@ -1,0 +1,21 @@
+import type { Outbound } from './outbound.js'
+import type { InboundMessage } from './stream.js'
+
+/** Channel 上层只依赖回复能力，不感知机器人 Webhook 或数字员工 DWS 协议。 */
+export interface ReplySink {
+  sendText(message: InboundMessage, text: string): Promise<boolean>
+  sendMarkdown(message: InboundMessage, title: string, text: string): Promise<boolean>
+}
+
+/** 现有机器人 Outbound 的 ReplySink 适配器。 */
+export class BotReplySink implements ReplySink {
+  constructor(private readonly outbound: Pick<Outbound, 'sendText' | 'sendMarkdown'>) {}
+
+  sendText(message: InboundMessage, text: string): Promise<boolean> {
+    return this.outbound.sendText(message.sessionWebhook, text)
+  }
+
+  sendMarkdown(message: InboundMessage, title: string, text: string): Promise<boolean> {
+    return this.outbound.sendMarkdown(message.sessionWebhook, title, text)
+  }
+}

--- a/src/setup-state.ts
+++ b/src/setup-state.ts
@@ -20,6 +20,39 @@ export type ImageMode = 'auto' | 'always' | 'never'
 export type SenderAccess = 'all' | 'owner' | 'allowlist'
 export type GroupAccess = 'all' | 'none' | 'allowlist'
 
+export interface DigitalEmployeeConfig {
+  agentUuid: string
+  name?: string
+  enabled: boolean
+  dwsProfile: string
+  operatorOpenDingTalkId: string
+  allowedDirectSenders: string[]
+  allowedGroups: string[]
+  sessionScope: 'chat' | 'chat-sender'
+  protocolVersion: 1
+}
+
+export interface DigitalEmployeeRegistration {
+  schemaVersion: 1
+  agentUuid: string
+  name?: string
+  dwsProfile: string
+  operatorOpenDingTalkId: string
+  protocolVersion: 1
+}
+
+export interface DigitalEmployeeAccess {
+  allowedDirectSenders: string[]
+  allowedGroups: string[]
+  sessionScope: 'chat' | 'chat-sender'
+}
+
+export interface DigitalEmployeeMutationResult {
+  status: 'created' | 'updated' | 'unchanged' | 'removed' | 'not_found'
+  restartRequired: boolean
+  agentUuid: string
+}
+
 export interface WebProfileConfig {
   dwsEnabled: boolean
   imageMode: ImageMode
@@ -31,6 +64,7 @@ export interface WebProfileConfig {
   groupAllowlist: string[]
   sessionScope: 'chat' | 'chat-sender'
   accounts: WebProfileAccount[]
+  digitalEmployees: DigitalEmployeeConfig[]
 }
 
 export interface WebProfileAccount extends AccountCredentialRefs {
@@ -472,6 +506,215 @@ async function writeWebProfile(
   await atomicPrivateWrite(file, stringify(entries, { lineWidth: 0 }))
 }
 
+const DIGITAL_EMPLOYEE_FIELDS = new Set([
+  'schemaVersion',
+  'agentUuid',
+  'name',
+  'dwsProfile',
+  'operatorOpenDingTalkId',
+  'protocolVersion',
+])
+const DIGITAL_EMPLOYEE_CONFIG_FIELDS = new Set([
+  'agentUuid',
+  'name',
+  'enabled',
+  'dwsProfile',
+  'operatorOpenDingTalkId',
+  'allowedDirectSenders',
+  'allowedGroups',
+  'sessionScope',
+  'protocolVersion',
+])
+const SENSITIVE_FIELD = /(token|auth.?code|secret|password|credential)/i
+
+function digitalEmployeeStringList(value: unknown, field: string): string[] {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string' || !item.trim())) {
+    throw new Error(`invalid_${field}`)
+  }
+  return [...new Set(value.map((item) => (item as string).trim()))]
+}
+
+function assertSafeDigitalEmployeeId(value: unknown): asserts value is string {
+  if (typeof value !== 'string' || !/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(value)) {
+    throw new Error('invalid_agent_uuid')
+  }
+}
+
+function assertDwsProfile(value: unknown): asserts value is string {
+  if (typeof value !== 'string' || value.length > 256 || !/^[^\s:]+:[^\s:]+$/.test(value)) {
+    throw new Error('invalid_dws_profile')
+  }
+}
+
+function assertStableIdentity(value: unknown, field: string): asserts value is string {
+  if (typeof value !== 'string' || !value.trim() || value.length > 256 || /\s/.test(value)) {
+    throw new Error(`invalid_${field}`)
+  }
+}
+
+function validateDigitalEmployeeRegistration(value: unknown): DigitalEmployeeRegistration {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('invalid_registration')
+  const raw = value as Record<string, unknown>
+  for (const field of Object.keys(raw)) {
+    if (SENSITIVE_FIELD.test(field)) throw new Error('sensitive_field')
+    if (!DIGITAL_EMPLOYEE_FIELDS.has(field)) throw new Error('unknown_field')
+  }
+  if (raw.schemaVersion !== 1) throw new Error('unsupported_schema_version')
+  if (raw.protocolVersion !== 1) throw new Error('unsupported_protocol_version')
+  assertSafeDigitalEmployeeId(raw.agentUuid)
+  assertDwsProfile(raw.dwsProfile)
+  assertStableIdentity(raw.operatorOpenDingTalkId, 'operator')
+  if (raw.name !== undefined && (typeof raw.name !== 'string' || !raw.name.trim() || raw.name.length > 128)) {
+    throw new Error('invalid_name')
+  }
+  return {
+    schemaVersion: 1,
+    agentUuid: raw.agentUuid,
+    ...(typeof raw.name === 'string' ? { name: raw.name.trim() } : {}),
+    dwsProfile: raw.dwsProfile,
+    operatorOpenDingTalkId: raw.operatorOpenDingTalkId,
+    protocolVersion: 1,
+  }
+}
+
+function parseDigitalEmployee(value: unknown): DigitalEmployeeConfig {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('invalid_digital_employee')
+  const raw = value as Record<string, unknown>
+  for (const field of Object.keys(raw)) {
+    if (SENSITIVE_FIELD.test(field)) throw new Error('sensitive_field')
+    if (!DIGITAL_EMPLOYEE_CONFIG_FIELDS.has(field)) throw new Error('unknown_digital_employee_field')
+  }
+  assertSafeDigitalEmployeeId(raw.agentUuid)
+  assertDwsProfile(raw.dwsProfile)
+  assertStableIdentity(raw.operatorOpenDingTalkId, 'operator')
+  if (raw.protocolVersion !== 1) throw new Error('unsupported_protocol_version')
+  if (raw.name !== undefined && (typeof raw.name !== 'string' || !raw.name.trim() || raw.name.length > 128)) {
+    throw new Error('invalid_name')
+  }
+  if (raw.enabled !== undefined && typeof raw.enabled !== 'boolean') throw new Error('invalid_enabled')
+  if (raw.sessionScope !== undefined && raw.sessionScope !== 'chat' && raw.sessionScope !== 'chat-sender') {
+    throw new Error('invalid_session_scope')
+  }
+  return {
+    agentUuid: raw.agentUuid,
+    ...(typeof raw.name === 'string' ? { name: raw.name.trim() } : {}),
+    enabled: raw.enabled !== false,
+    dwsProfile: raw.dwsProfile,
+    operatorOpenDingTalkId: raw.operatorOpenDingTalkId,
+    allowedDirectSenders:
+      raw.allowedDirectSenders === undefined
+        ? []
+        : digitalEmployeeStringList(raw.allowedDirectSenders, 'allowed_direct_senders'),
+    allowedGroups:
+      raw.allowedGroups === undefined ? [] : digitalEmployeeStringList(raw.allowedGroups, 'allowed_groups'),
+    sessionScope: raw.sessionScope === 'chat-sender' ? 'chat-sender' : 'chat',
+    protocolVersion: 1,
+  }
+}
+
+function parseDigitalEmployees(value: unknown): DigitalEmployeeConfig[] {
+  if (value === undefined) return []
+  if (!Array.isArray(value)) throw new Error('invalid_digital_employees')
+  const employees = value.map(parseDigitalEmployee)
+  const uuids = new Set<string>()
+  const profiles = new Set<string>()
+  for (const employee of employees) {
+    if (uuids.has(employee.agentUuid)) throw new Error('duplicate_agent_uuid')
+    if (profiles.has(employee.dwsProfile)) throw new Error('duplicate_dws_profile')
+    uuids.add(employee.agentUuid)
+    profiles.add(employee.dwsProfile)
+  }
+  return employees
+}
+
+/** 配置加载、运行时和 CLI 共用同一套严格数字员工校验。 */
+export function validateDigitalEmployeeConfigs(value: unknown): DigitalEmployeeConfig[] {
+  return parseDigitalEmployees(value)
+}
+
+export async function registerDigitalEmployee(dshHome: string, value: unknown): Promise<DigitalEmployeeMutationResult> {
+  const registration = validateDigitalEmployeeRegistration(value)
+  const file = path.join(dshHome, 'profiles', 'web', 'cordis.patch.yml')
+  return withWebProfileLock(file, async () => {
+    const entries = profileEntries(await readOptional(file), file)
+    const { current, config } = ownedPluginConfig(entries)
+    const employees = parseDigitalEmployees(config.digitalEmployees)
+    const duplicateProfile = employees.find(
+      (employee) => employee.dwsProfile === registration.dwsProfile && employee.agentUuid !== registration.agentUuid,
+    )
+    if (duplicateProfile) throw new Error('duplicate_dws_profile')
+    const existing = employees.find((employee) => employee.agentUuid === registration.agentUuid)
+    const next: DigitalEmployeeConfig = {
+      agentUuid: registration.agentUuid,
+      ...(registration.name ? { name: registration.name } : {}),
+      enabled: true,
+      dwsProfile: registration.dwsProfile,
+      operatorOpenDingTalkId: registration.operatorOpenDingTalkId,
+      allowedDirectSenders: existing?.allowedDirectSenders ?? [],
+      allowedGroups: existing?.allowedGroups ?? [],
+      sessionScope: existing?.sessionScope ?? 'chat',
+      protocolVersion: 1,
+    }
+    if (existing !== undefined && JSON.stringify(existing) === JSON.stringify(next)) {
+      return { status: 'unchanged', restartRequired: false, agentUuid: registration.agentUuid }
+    }
+    if (existing) {
+      if (!registration.name) delete existing.name
+      Object.assign(existing, next)
+    } else employees.push(next)
+    config.digitalEmployees = employees
+    await writeWebProfile(file, entries, current, config)
+    return {
+      status: existing ? 'updated' : 'created',
+      restartRequired: true,
+      agentUuid: registration.agentUuid,
+    }
+  })
+}
+
+export async function unregisterDigitalEmployee(
+  dshHome: string,
+  agentUuid: string,
+): Promise<DigitalEmployeeMutationResult> {
+  assertSafeDigitalEmployeeId(agentUuid)
+  const file = path.join(dshHome, 'profiles', 'web', 'cordis.patch.yml')
+  return withWebProfileLock(file, async () => {
+    const entries = profileEntries(await readOptional(file), file)
+    const { current, config } = ownedPluginConfig(entries)
+    const employees = parseDigitalEmployees(config.digitalEmployees)
+    const remaining = employees.filter((employee) => employee.agentUuid !== agentUuid)
+    if (remaining.length === employees.length) {
+      return { status: 'not_found', restartRequired: false, agentUuid }
+    }
+    config.digitalEmployees = remaining
+    await writeWebProfile(file, entries, current, config)
+    return { status: 'removed', restartRequired: true, agentUuid }
+  })
+}
+
+export async function updateDigitalEmployeeAccess(
+  dshHome: string,
+  agentUuid: string,
+  access: DigitalEmployeeAccess,
+): Promise<string> {
+  assertSafeDigitalEmployeeId(agentUuid)
+  const allowedDirectSenders = digitalEmployeeStringList(access.allowedDirectSenders, 'allowed_direct_senders')
+  const allowedGroups = digitalEmployeeStringList(access.allowedGroups, 'allowed_groups')
+  if (access.sessionScope !== 'chat' && access.sessionScope !== 'chat-sender') throw new Error('invalid_session_scope')
+  const file = path.join(dshHome, 'profiles', 'web', 'cordis.patch.yml')
+  return withWebProfileLock(file, async () => {
+    const entries = profileEntries(await readOptional(file), file)
+    const { current, config } = ownedPluginConfig(entries)
+    const employees = parseDigitalEmployees(config.digitalEmployees)
+    const employee = employees.find((item) => item.agentUuid === agentUuid)
+    if (!employee) throw new Error('digital_employee_not_found')
+    Object.assign(employee, { ...access, allowedDirectSenders, allowedGroups })
+    config.digitalEmployees = employees
+    await writeWebProfile(file, entries, current, config)
+    return file
+  })
+}
+
 function upsertOwnedAccount(
   config: Record<string, unknown>,
   id: string,
@@ -613,6 +856,7 @@ export async function loadWebProfileConfig(dshHome: string): Promise<WebProfileC
       groupAllowlist: [],
       sessionScope: 'chat',
       accounts: [],
+      digitalEmployees: [],
     }
   }
   const parsed = parse(source, { uniqueKeys: true })
@@ -669,6 +913,7 @@ export async function loadWebProfileConfig(dshHome: string): Promise<WebProfileC
         return [account]
       })
     : []
+  const digitalEmployees = parseDigitalEmployees(config.digitalEmployees)
   return {
     dwsEnabled: tools.enabled === true,
     imageMode,
@@ -681,6 +926,7 @@ export async function loadWebProfileConfig(dshHome: string): Promise<WebProfileC
     groupAllowlist,
     sessionScope: config.sessionScope === 'chat-sender' ? 'chat-sender' : 'chat',
     accounts,
+    digitalEmployees,
   }
 }
 
@@ -700,4 +946,22 @@ export function enabledWebProfileAccounts(profile: WebProfileConfig): WebProfile
       sessionScope: profile.sessionScope,
     },
   ]
+}
+
+/**
+ * 诊断/setup 在数字员工与旧版单机器人并存时仍保留根级机器人兼容读取；
+ * 纯数字员工且没有旧凭据时不虚构一个失败机器人。
+ */
+export async function enabledConfiguredWebProfileAccounts(
+  dshHome: string,
+  profile: WebProfileConfig,
+): Promise<WebProfileAccount[]> {
+  const accounts = enabledWebProfileAccounts(profile)
+  if (profile.accounts.length || !profile.digitalEmployees.some((employee) => employee.enabled)) return accounts
+  try {
+    return (await loadDingTalkAccountCredentials(dshHome, DEFAULT_ACCOUNT_ID, accounts[0])) ? accounts : []
+  } catch {
+    // 凭据文件异常也必须保留默认账号，让 doctor 输出稳定的脱敏错误。
+    return accounts
+  }
 }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -2,12 +2,14 @@ import path from 'node:path'
 
 import { accountStateDir, assertAccountId, DEFAULT_ACCOUNT_ID } from './accounts.js'
 import { collectDiagnostics } from './diagnostics.js'
+import { collectDoctorReport } from './doctor-report.js'
 import { diagnoseCommandFailure, formatInstallFailure } from './install-diagnostics.js'
 import { isSupportedNodeVersion } from './node-version.js'
 import { syncWebProfileNpmRegistry } from './npm-registry.js'
 import { beginRegistration, renderQr, waitForCredentials } from './onboard.js'
 import { issueBindingChallenge, OwnerBinding } from './owner.js'
 import {
+  enabledConfiguredWebProfileAccounts,
   enabledWebProfileAccounts,
   loadDingTalkCredentials,
   loadDingTalkAccountCredentials,
@@ -18,8 +20,10 @@ import {
   upsertWebProfileAccount,
   updateWebProfileAccountAccess,
   updateWebProfileConfig,
+  updateDigitalEmployeeAccess,
   type CredentialDocumentLayout,
   type DingTalkCredentials,
+  type DigitalEmployeeConfig,
   type GroupAccess,
   type ImageMode,
   type SenderAccess,
@@ -99,7 +103,7 @@ export interface PrivateAccountSetupResult {
   challengeExpiresAt?: number
 }
 
-type SetupAction = 'full' | 'add-account' | 'credentials' | 'features' | 'binding' | 'doctor'
+type SetupAction = 'full' | 'add-account' | 'credentials' | 'features' | 'binding' | 'digital-employees' | 'doctor'
 
 function cleanVersion(output: string): string {
   const trimmed = output.trim()
@@ -594,11 +598,81 @@ async function chooseRobot(
   )
 }
 
+function parseIdentityList(value: string): string[] {
+  return [
+    ...new Set(
+      value
+        .split(/[\s,，]+/u)
+        .map((item) => item.trim())
+        .filter(Boolean),
+    ),
+  ]
+}
+
+async function configureDigitalEmployeeAccess(
+  ui: SetupUi,
+  dshHome: string,
+  employees: DigitalEmployeeConfig[],
+): Promise<void> {
+  if (!employees.length) throw new Error('当前没有已接入的数字员工；请先通过 DWS connect --channel dsh 接入')
+  const agentUuid =
+    employees.length === 1
+      ? employees[0].agentUuid
+      : await ui.select(
+          'digitalEmployee',
+          '请选择要管理白名单的数字员工',
+          employees.map((employee) => ({
+            value: employee.agentUuid,
+            label: `${employee.name || employee.agentUuid}（${employee.dwsProfile}）`,
+          })),
+          employees[0].agentUuid,
+        )
+  const employee = employees.find((item) => item.agentUuid === agentUuid)
+  if (!employee) throw new Error('digital_employee_not_found')
+  const operatorConfirmed = await ui.confirm(
+    'confirmDigitalEmployeeOperator',
+    `确认 operator OpenDingTalkId 为 ${employee.operatorOpenDingTalkId}？敏感操作只接受该身份私聊确认。`,
+    true,
+  )
+  if (!operatorConfirmed) throw new Error('operator_confirmation_required')
+  const allowedDirectSenders = parseIdentityList(
+    await ui.optionalText(
+      'digitalEmployeeDirectAllowlist',
+      '允许私聊的 OpenDingTalkId（逗号分隔；留空表示只有 operator）',
+      employee.allowedDirectSenders.join(','),
+    ),
+  )
+  const allowedGroups = parseIdentityList(
+    await ui.optionalText(
+      'digitalEmployeeGroupAllowlist',
+      '允许群聊的 openConversationId（逗号分隔；留空表示拒绝所有群）',
+      employee.allowedGroups.join(','),
+    ),
+  )
+  const sessionScope = await ui.select(
+    'digitalEmployeeSessionScope',
+    '群聊会话隔离粒度',
+    [
+      { value: 'chat', label: '每个群一个 Session' },
+      { value: 'chat-sender', label: '群内每个发送者独立 Session' },
+    ],
+    employee.sessionScope,
+  )
+  await updateDigitalEmployeeAccess(dshHome, employee.agentUuid, {
+    allowedDirectSenders,
+    allowedGroups,
+    sessionScope,
+  })
+  ui.success(
+    `数字员工 ${employee.name || employee.agentUuid} 白名单已更新：私聊 ${allowedDirectSenders.length} 人，群聊 ${allowedGroups.length} 个。`,
+  )
+}
+
 async function showOfflineDoctor(options: RunGuidedSetupOptions): Promise<void> {
   const profile = await loadWebProfileConfig(options.dshHome)
-  const accounts = enabledWebProfileAccounts(profile)
-  if (!accounts.length) {
-    options.ui.note('WARN 钉钉机器人：profile 中没有启用的钉钉机器人')
+  const accounts = await enabledConfiguredWebProfileAccounts(options.dshHome, profile)
+  if (!accounts.length && !profile.digitalEmployees.some((employee) => employee.enabled)) {
+    options.ui.note('WARN 钉钉 Channel：profile 中没有启用的机器人或数字员工')
     return
   }
   for (const account of accounts) {
@@ -612,6 +686,17 @@ async function showOfflineDoctor(options: RunGuidedSetupOptions): Promise<void> 
     })
     if (accounts.length > 1) options.ui.note(`[${account.id}]`)
     for (const check of checks) options.ui.note(`${check.status.toUpperCase()} ${check.title}：${check.detail}`)
+  }
+  if (profile.digitalEmployees.some((employee) => employee.enabled)) {
+    const report = await collectDoctorReport({
+      mode: 'offline',
+      dshHome: options.dshHome,
+      stateDir: options.stateDir,
+    })
+    for (const employee of report.digitalEmployees) {
+      options.ui.note(`[数字员工 ${employee.agentUuid}] ${employee.dwsProfile}`)
+      for (const check of employee.checks) options.ui.note(`${check.status.toUpperCase()} ${check.message}`)
+    }
   }
 }
 
@@ -665,21 +750,30 @@ export async function runGuidedSetup(options: RunGuidedSetupOptions): Promise<Gu
   const robots = profile.accounts
   const robotIds = robots.map((robot) => robot.id)
   const hasExistingRobot = robotIds.length > 0
-  const action: SetupAction = hasExistingRobot
-    ? await ui.select(
-        'setupAction',
-        '请选择要执行的配置操作',
-        [
-          { value: 'full', label: '重新执行完整引导' },
-          { value: 'add-account', label: '新增钉钉机器人' },
-          { value: 'credentials', label: '修改现有机器人凭据' },
-          { value: 'features', label: '修改 DWS、图片与访问范围' },
-          { value: 'binding', label: '查看或重新生成机器人管理员绑定口令' },
-          { value: 'doctor', label: '运行只读诊断' },
-        ],
-        'features',
-      )
-    : 'full'
+  const hasDigitalEmployees = profile.digitalEmployees.length > 0
+  const action: SetupAction =
+    hasExistingRobot || hasDigitalEmployees
+      ? await ui.select(
+          'setupAction',
+          '请选择要执行的配置操作',
+          [
+            { value: 'full', label: '重新执行完整机器人引导' },
+            { value: 'add-account', label: '新增钉钉机器人' },
+            ...(hasExistingRobot
+              ? ([
+                  { value: 'credentials', label: '修改现有机器人凭据' },
+                  { value: 'features', label: '修改 DWS、图片与访问范围' },
+                  { value: 'binding', label: '查看或重新生成机器人管理员绑定口令' },
+                ] as const)
+              : []),
+            ...(hasDigitalEmployees
+              ? ([{ value: 'digital-employees', label: '管理数字员工 operator 与白名单' }] as const)
+              : []),
+            { value: 'doctor', label: '运行只读诊断' },
+          ],
+          hasExistingRobot ? 'features' : 'digital-employees',
+        )
+      : 'full'
 
   if (action === 'doctor') {
     await showOfflineDoctor(options)
@@ -705,6 +799,8 @@ export async function runGuidedSetup(options: RunGuidedSetupOptions): Promise<Gu
     await configureCredentials(options, selectedRobot)
   } else if (action === 'features') {
     selectedRobot = await chooseRobot(ui, stateDir, robots, '请选择要修改访问范围的钉钉机器人')
+  } else if (action === 'digital-employees') {
+    await configureDigitalEmployeeAccess(ui, dshHome, profile.digitalEmployees)
   }
   if (action === 'full' || action === 'features') {
     await configureFeatures(options, selectedRobot, !hasExistingRobot)
@@ -723,7 +819,8 @@ export async function runGuidedSetup(options: RunGuidedSetupOptions): Promise<Gu
     const selected = robots.find((robot) => robot.id === selectedRobot)
     if (selected && configureBinding(ui, stateDir, selected, true)) bindingPrepared.add(selectedRobot)
   }
-  const enabledRobots = enabledWebProfileAccounts(await loadWebProfileConfig(dshHome))
+  const refreshedProfile = await loadWebProfileConfig(dshHome)
+  const enabledRobots = refreshedProfile.accounts.length ? enabledWebProfileAccounts(refreshedProfile) : []
   const unboundRobots = enabledRobots.filter((robot) => !isRobotBound(stateDir, robot))
   for (const robot of unboundRobots) {
     if (bindingPrepared.has(robot.id)) continue

--- a/test/digital-employee-audit.test.mjs
+++ b/test/digital-employee-audit.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import { LocalDigitalEmployeeAuditLog } from '../lib/digital-employee-audit.js'
+
+test('员工级本地审计使用私有 JSONL 且不保存消息正文', async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-de-audit-'))
+  t.after(() => rm(root, { recursive: true, force: true }))
+  const audit = new LocalDigitalEmployeeAuditLog(root, 'employee-1')
+
+  await Promise.all([
+    audit.audit({ eventId: 'event-1', operationType: 'access_check', status: 'accepted' }),
+    audit.audit({ eventId: 'event-2', operationType: 'reply', status: 'delivered', replyMessageId: 'message-2' }),
+  ])
+
+  const directory = path.join(root, 'audit')
+  const file = path.join(directory, 'employee-1.jsonl')
+  assert.equal((await stat(directory)).mode & 0o777, 0o700)
+  assert.equal((await stat(file)).mode & 0o777, 0o600)
+  const content = await readFile(file, 'utf8')
+  const entries = content.trim().split('\n').map(JSON.parse)
+  assert.equal(entries.length, 2)
+  assert.deepEqual(
+    entries.map((entry) => entry.eventId),
+    ['event-1', 'event-2'],
+  )
+  assert.doesNotMatch(content, /text|content|正文/i)
+})

--- a/test/digital-employee-audit.test.mjs
+++ b/test/digital-employee-audit.test.mjs
@@ -18,8 +18,10 @@ test('员工级本地审计使用私有 JSONL 且不保存消息正文', async (
 
   const directory = path.join(root, 'audit')
   const file = path.join(directory, 'employee-1.jsonl')
-  assert.equal((await stat(directory)).mode & 0o777, 0o700)
-  assert.equal((await stat(file)).mode & 0o777, 0o600)
+  if (process.platform !== 'win32') {
+    assert.equal((await stat(directory)).mode & 0o777, 0o700)
+    assert.equal((await stat(file)).mode & 0o777, 0o600)
+  }
   const content = await readFile(file, 'utf8')
   const entries = content.trim().split('\n').map(JSON.parse)
   assert.equal(entries.length, 2)

--- a/test/digital-employee-config.test.mjs
+++ b/test/digital-employee-config.test.mjs
@@ -1,0 +1,198 @@
+import assert from 'node:assert/strict'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import test from 'node:test'
+import { parse } from 'yaml'
+
+import {
+  loadWebProfileConfig,
+  registerDigitalEmployee,
+  unregisterDigitalEmployee,
+  updateDigitalEmployeeAccess,
+} from '../lib/setup-state.js'
+
+const registration = {
+  schemaVersion: 1,
+  agentUuid: 'employee-11111111-2222-4333-8444-555555555555',
+  name: '值班助手',
+  dwsProfile: 'corp-example:user-example',
+  operatorOpenDingTalkId: 'operator-open-id',
+  protocolVersion: 1,
+}
+
+test('register 幂等写入非敏感数字员工配置并保留白名单', async (t) => {
+  const dshHome = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-de-config-'))
+  t.after(() => rm(dshHome, { recursive: true, force: true }))
+
+  assert.deepEqual(await registerDigitalEmployee(dshHome, registration), {
+    status: 'created',
+    restartRequired: true,
+    agentUuid: registration.agentUuid,
+  })
+  await updateDigitalEmployeeAccess(dshHome, registration.agentUuid, {
+    allowedDirectSenders: ['direct-open-id'],
+    allowedGroups: ['group-conversation-id'],
+    sessionScope: 'chat-sender',
+  })
+  assert.deepEqual(await registerDigitalEmployee(dshHome, registration), {
+    status: 'unchanged',
+    restartRequired: false,
+    agentUuid: registration.agentUuid,
+  })
+
+  const profile = await loadWebProfileConfig(dshHome)
+  assert.deepEqual(profile.digitalEmployees, [
+    {
+      agentUuid: registration.agentUuid,
+      name: '值班助手',
+      enabled: true,
+      dwsProfile: 'corp-example:user-example',
+      operatorOpenDingTalkId: 'operator-open-id',
+      allowedDirectSenders: ['direct-open-id'],
+      allowedGroups: ['group-conversation-id'],
+      sessionScope: 'chat-sender',
+      protocolVersion: 1,
+    },
+  ])
+
+  const source = await readFile(path.join(dshHome, 'profiles', 'web', 'cordis.patch.yml'), 'utf8')
+  assert.doesNotMatch(source, /token|authCode|secret/i)
+})
+
+test('register 拒绝敏感字段、重复 profile 和不安全标识且不改写已有配置', async (t) => {
+  const dshHome = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-de-invalid-'))
+  t.after(() => rm(dshHome, { recursive: true, force: true }))
+  await registerDigitalEmployee(dshHome, registration)
+
+  await assert.rejects(
+    () => registerDigitalEmployee(dshHome, { ...registration, agentUuid: 'employee-other', accessToken: 'forbidden' }),
+    /sensitive_field/,
+  )
+  await assert.rejects(
+    () => registerDigitalEmployee(dshHome, { ...registration, agentUuid: 'employee-other' }),
+    /duplicate_dws_profile/,
+  )
+  await assert.rejects(
+    () => registerDigitalEmployee(dshHome, { ...registration, agentUuid: '../../escape', dwsProfile: 'corp:user-2' }),
+    /invalid_agent_uuid/,
+  )
+  await assert.rejects(
+    () =>
+      registerDigitalEmployee(dshHome, {
+        ...registration,
+        agentUuid: 'employee-other',
+        dwsProfile: 'corp:user-2',
+        executablePath: '/tmp/untrusted-dws',
+      }),
+    /unknown_field/,
+  )
+
+  assert.equal((await loadWebProfileConfig(dshHome)).digitalEmployees.length, 1)
+})
+
+test('register 对缺字段、空 operator 和未知 schema/protocol 版本 fail-closed', async (t) => {
+  const dshHome = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-de-required-'))
+  t.after(() => rm(dshHome, { recursive: true, force: true }))
+  const withoutProfile = { ...registration }
+  delete withoutProfile.dwsProfile
+  await assert.rejects(() => registerDigitalEmployee(dshHome, withoutProfile), /invalid_dws_profile/)
+  await assert.rejects(
+    () => registerDigitalEmployee(dshHome, { ...registration, operatorOpenDingTalkId: '' }),
+    /invalid_operator/,
+  )
+  await assert.rejects(
+    () => registerDigitalEmployee(dshHome, { ...registration, schemaVersion: 2 }),
+    /unsupported_schema_version/,
+  )
+  await assert.rejects(
+    () => registerDigitalEmployee(dshHome, { ...registration, protocolVersion: 2 }),
+    /unsupported_protocol_version/,
+  )
+  assert.deepEqual((await loadWebProfileConfig(dshHome)).digitalEmployees, [])
+})
+
+test('兼容读取对手工写入的敏感字段 fail-closed', async (t) => {
+  const dshHome = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-de-manual-secret-'))
+  t.after(() => rm(dshHome, { recursive: true, force: true }))
+  const file = path.join(dshHome, 'profiles', 'web', 'cordis.patch.yml')
+  await mkdir(path.dirname(file), { recursive: true, mode: 0o700 })
+  await writeFile(
+    file,
+    [
+      '- id: dingtalk-channel',
+      '  config:',
+      '    digitalEmployees:',
+      `      - agentUuid: ${registration.agentUuid}`,
+      `        dwsProfile: ${registration.dwsProfile}`,
+      `        operatorOpenDingTalkId: ${registration.operatorOpenDingTalkId}`,
+      '        protocolVersion: 1',
+      '        accessToken: forbidden',
+      '',
+    ].join('\n'),
+  )
+  await assert.rejects(() => loadWebProfileConfig(dshHome), /sensitive_field/)
+})
+
+test('unregister 只移除目标数字员工并保持其他插件配置', async (t) => {
+  const dshHome = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-de-remove-'))
+  t.after(() => rm(dshHome, { recursive: true, force: true }))
+  await registerDigitalEmployee(dshHome, registration)
+  await registerDigitalEmployee(dshHome, {
+    ...registration,
+    agentUuid: 'employee-second',
+    dwsProfile: 'corp-example:user-second',
+  })
+
+  assert.deepEqual(await unregisterDigitalEmployee(dshHome, registration.agentUuid), {
+    status: 'removed',
+    restartRequired: true,
+    agentUuid: registration.agentUuid,
+  })
+  assert.deepEqual(
+    (await loadWebProfileConfig(dshHome)).digitalEmployees.map((item) => item.agentUuid),
+    ['employee-second'],
+  )
+})
+
+test('CLI 通过 stdin 注册并用显式 yes 注销数字员工', async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-de-cli-'))
+  const dshHome = path.join(root, '.dsh')
+  t.after(() => rm(root, { recursive: true, force: true }))
+  const env = { ...process.env, HOME: root, DSH_HOME: dshHome }
+
+  const registered = spawnSync(process.execPath, ['lib/bin.js', 'digital-employee', 'register', '--stdin', '--json'], {
+    cwd: path.resolve('.'),
+    encoding: 'utf8',
+    env,
+    input: JSON.stringify(registration),
+  })
+  assert.equal(registered.status, 0, registered.stderr)
+  assert.deepEqual(JSON.parse(registered.stdout), {
+    schemaVersion: 1,
+    kind: 'digital_employee_registration',
+    status: 'created',
+    restartRequired: true,
+    agentUuid: registration.agentUuid,
+  })
+
+  const denied = spawnSync(
+    process.execPath,
+    ['lib/bin.js', 'digital-employee', 'unregister', '--agent-uuid', registration.agentUuid, '--json'],
+    { cwd: path.resolve('.'), encoding: 'utf8', env },
+  )
+  assert.equal(denied.status, 2)
+  assert.equal(JSON.parse(denied.stdout).error.code, 'confirmation_required')
+
+  const removed = spawnSync(
+    process.execPath,
+    ['lib/bin.js', 'digital-employee', 'unregister', '--agent-uuid', registration.agentUuid, '--json', '--yes'],
+    { cwd: path.resolve('.'), encoding: 'utf8', env },
+  )
+  assert.equal(removed.status, 0, removed.stderr)
+  assert.equal(JSON.parse(removed.stdout).status, 'removed')
+
+  const profile = parse(await readFile(path.join(dshHome, 'profiles', 'web', 'cordis.patch.yml'), 'utf8'))
+  assert.deepEqual(profile[0].config.digitalEmployees, [])
+})

--- a/test/digital-employee-renderer.test.mjs
+++ b/test/digital-employee-renderer.test.mjs
@@ -1,0 +1,197 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { DigitalEmployeeApprovalManager, DigitalEmployeeTextRenderer } from '../lib/digital-employee-renderer.js'
+
+const event = {
+  schemaVersion: 1,
+  eventId: 'event-renderer-1',
+  messageId: 'message-renderer-1',
+  conversationId: 'conversation-1',
+  conversationType: 'direct',
+  senderOpenDingTalkId: 'allowed-user',
+  senderName: '用户',
+  text: '执行任务',
+  createdAt: '1',
+}
+
+const message = {
+  msgId: event.messageId,
+  conversationId: event.conversationId,
+  conversationType: 'direct',
+  senderStaffId: event.senderOpenDingTalkId,
+  senderNick: event.senderName,
+  text: event.text,
+  createAt: event.createdAt,
+  sessionWebhook: '',
+}
+
+test('数字员工文本 Renderer 只在 turn/end 发送一次引用回复并等待投递结束', async () => {
+  const replies = []
+  const runtime = {
+    async reply(receivedEvent, sessionId, text) {
+      replies.push({ receivedEvent, sessionId, text })
+      return {
+        openMessageId: 'outgoing-renderer-1',
+        conversationId: event.conversationId,
+        deliveryStatus: 'unknown',
+        idempotencyKey: 'key',
+      }
+    },
+  }
+  const renderer = new DigitalEmployeeTextRenderer(runtime, () => {})
+  renderer.accept({ event, message, scopeKey: 'employee:conversation-1' })
+  let settled = false
+  const promise = renderer.onInbound('session-1', message).then(() => {
+    settled = true
+  })
+  renderer.onSessionEvent(
+    { id: 'session-1' },
+    { type: 'assistant/message', data: { message: { content: [{ type: 'text', text: '最终文本' }] } } },
+  )
+  assert.equal(settled, false)
+  renderer.onSessionEvent({ id: 'session-1' }, { type: 'turn/end', data: { reason: {} } })
+  await promise
+
+  assert.equal(replies.length, 1)
+  assert.equal(replies[0].receivedEvent, event)
+  assert.equal(replies[0].sessionId, 'session-1')
+  assert.equal(replies[0].text, '最终文本')
+})
+
+test('敏感审批只接受 operator 私聊中的精确一次性确认码', async () => {
+  const delivered = []
+  const audits = []
+  const runtime = {
+    async operatorPrivate(text, operationType) {
+      delivered.push({ text, operationType })
+      return {
+        openMessageId: 'operator-message',
+        conversationId: 'operator-chat',
+        deliveryStatus: 'delivered',
+        idempotencyKey: 'key',
+      }
+    },
+    async audit(fields) {
+      audits.push(fields)
+    },
+  }
+  const manager = new DigitalEmployeeApprovalManager(runtime, 'operator-open-id', 1_000, () => {})
+  let listener
+  manager.install({
+    on(name, value) {
+      if (name === 'approval/request') listener = value
+      return () => {}
+    },
+  })
+  manager.bindSession('session-approval', event)
+  const approval = listener(
+    {
+      agent: { id: 'session-approval' },
+      toolName: 'bash',
+      reason: '修改文件',
+    },
+    async () => 'unavailable',
+  )
+  while (!delivered.length) await new Promise((resolve) => setImmediate(resolve))
+  const code = delivered[0].text.match(/确认 ([A-F0-9]{6})/)?.[1]
+  assert.ok(code)
+  assert.equal(delivered[0].operationType, 'approval_request')
+
+  assert.equal(
+    await manager.handleInbound({
+      event: { ...event, senderOpenDingTalkId: 'allowed-user', text: `确认 ${code}` },
+      message,
+      scopeKey: 'x',
+    }),
+    false,
+  )
+  assert.equal(
+    await manager.handleInbound({
+      event: {
+        ...event,
+        conversationType: 'group',
+        senderOpenDingTalkId: 'operator-open-id',
+        text: `确认 ${code}`,
+      },
+      message,
+      scopeKey: 'x',
+    }),
+    false,
+  )
+  assert.equal(
+    await manager.handleInbound({
+      event: {
+        ...event,
+        conversationType: 'direct',
+        senderOpenDingTalkId: 'operator-open-id',
+        text: `确认 ${code}`,
+      },
+      message,
+      scopeKey: 'x',
+    }),
+    true,
+  )
+  assert.equal(await approval, 'allowed-once')
+  assert.deepEqual(
+    audits.map(({ sessionId, toolName, operationType, status }) => ({ sessionId, toolName, operationType, status })),
+    [
+      { sessionId: 'session-approval', toolName: 'bash', operationType: 'approval_request', status: 'delivered' },
+      { sessionId: 'session-approval', toolName: 'bash', operationType: 'approval_response', status: 'allowed_once' },
+    ],
+  )
+})
+
+test('DSH 原生用户问题通过文本 ReplySink 提问，并只消费原会话原发送者回答', async () => {
+  const prompts = []
+  const listeners = new Map()
+  const runtime = {
+    async reply(receivedEvent, sessionId, text, purpose) {
+      prompts.push({ receivedEvent, sessionId, text, purpose })
+      return {
+        openMessageId: 'question-prompt',
+        conversationId: receivedEvent.conversationId,
+        deliveryStatus: 'delivered',
+        idempotencyKey: 'key',
+      }
+    },
+  }
+  const manager = new DigitalEmployeeApprovalManager(runtime, 'operator-open-id', 1_000, () => {})
+  manager.install({
+    agent: { id: 'session-question' },
+    on(name, listener) {
+      listeners.set(name, listener)
+      return () => listeners.delete(name)
+    },
+  })
+  manager.bindSession('session-question', event)
+  const response = listeners.get('user-questions/request')(
+    {
+      agent: { id: 'session-question' },
+      questions: [
+        {
+          id: 'choice',
+          question: '选择执行方式',
+          options: [{ label: '安全模式' }, { label: '快速模式' }],
+        },
+      ],
+    },
+    async () => ({ answers: [] }),
+  )
+  while (!prompts.length) await new Promise((resolve) => setImmediate(resolve))
+  assert.match(prompts[0].text, /1\) 安全模式/)
+  assert.match(prompts[0].purpose, /^question_prompt_/)
+
+  const answerEvent = { ...event, text: '2' }
+  assert.equal(manager.expects(answerEvent), true)
+  assert.equal(
+    await manager.handleInbound({
+      event: { ...answerEvent, senderOpenDingTalkId: 'someone-else' },
+      message,
+      scopeKey: 'x',
+    }),
+    false,
+  )
+  assert.equal(await manager.handleInbound({ event: answerEvent, message, scopeKey: 'x' }), true)
+  assert.deepEqual(await response, { answers: [{ id: 'choice', selected: ['快速模式'] }] })
+})

--- a/test/digital-employee-routing.test.mjs
+++ b/test/digital-employee-routing.test.mjs
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { routeDigitalEmployeePreTask } from '../lib/digital-employee-routing.js'
+
+function input(text) {
+  return {
+    event: {},
+    message: { msgId: 'message-1', text },
+    scopeKey: 'employee:conversation',
+  }
+}
+
+test('/new 和 /stop 在等待问题时仍优先走会话控制', async () => {
+  const calls = []
+  const commands = {
+    async handle(message) {
+      calls.push(`command:${message.text}`)
+      return true
+    },
+  }
+  const interactive = {
+    async handleInbound(value) {
+      calls.push(`interactive:${value.message.text}`)
+      return true
+    },
+  }
+
+  assert.equal(await routeDigitalEmployeePreTask(input('/new'), commands, interactive), true)
+  assert.deepEqual(calls, ['command:/new'])
+})
+
+test('非会话控制消息先交给待回答问题，再交给普通命令', async () => {
+  const calls = []
+  const commands = {
+    async handle(message) {
+      calls.push(`command:${message.text}`)
+      return false
+    },
+  }
+  const interactive = {
+    async handleInbound(value) {
+      calls.push(`interactive:${value.message.text}`)
+      return true
+    },
+  }
+
+  assert.equal(await routeDigitalEmployeePreTask(input('1'), commands, interactive), true)
+  assert.deepEqual(calls, ['interactive:1'])
+})

--- a/test/digital-employee-runtime.test.mjs
+++ b/test/digital-employee-runtime.test.mjs
@@ -172,19 +172,25 @@ const args = process.argv.slice(2)
 const file = process.env.FAKE_DWS_SUBSCRIPTION_STATE
 const readState = () => { try { return JSON.parse(fs.readFileSync(file, 'utf8')) } catch { return { attempts: 0, active: 0, maxActive: 0 } } }
 const writeState = (state) => fs.writeFileSync(file, JSON.stringify(state))
+const isAlive = (pid) => {
+  if (!Number.isInteger(pid) || pid <= 0) return false
+  try { process.kill(pid, 0); return true } catch { return false }
+}
 if (args.includes('capabilities')) {
   process.stdout.write(JSON.stringify({ ok: true, outcome: 'success', data: { schemaVersion: 1, protocolVersion: 1, auditMode: 'local_required', capabilities: { eventConsume: true, replyStdin: true, operatorPrivateStdin: true } }, meta: {} }))
   process.exit(0)
 }
 if (args.includes('consume')) {
   const state = readState()
+  const overlapsPrevious = state.pid !== process.pid && isAlive(state.pid)
   state.attempts++
-  state.active++
+  state.active = overlapsPrevious ? 2 : 1
   state.maxActive = Math.max(state.maxActive, state.active)
+  state.pid = process.pid
   writeState(state)
   const finish = () => {
     const latest = readState()
-    latest.active--
+    if (latest.pid === process.pid) latest.active = 0
     writeState(latest)
     process.exit(0)
   }
@@ -487,7 +493,10 @@ test('ready 超时会等待旧订阅进程退出后再重试，不并行创建�
 
   await runtime.start()
   const state = JSON.parse(await readFile(stateFile, 'utf8'))
-  assert.deepEqual(state, { attempts: 2, active: 1, maxActive: 1 })
+  assert.deepEqual(
+    { attempts: state.attempts, active: state.active, maxActive: state.maxActive },
+    { attempts: 2, active: 1, maxActive: 1 },
+  )
 })
 
 test('本地审计不可写时 fail-closed，不创建新 Agent 任务', async (t) => {

--- a/test/digital-employee-runtime.test.mjs
+++ b/test/digital-employee-runtime.test.mjs
@@ -27,19 +27,16 @@ const employee = {
   protocolVersion: 1,
 }
 
-async function writeFakeDwsCommand(root, name, source) {
-  const command = path.join(root, name)
-  if (process.platform !== 'win32') {
+async function writeFakeDwsCommand(root, name, source, pathCommand = false) {
+  if (pathCommand) {
+    const command = path.join(root, name)
     await writeFile(command, source, { mode: 0o755 })
     await chmod(command, 0o755)
-    return command
+    return { dwsCommand: command, dwsArgsPrefix: [] }
   }
-
   const script = path.join(root, `${name}.cjs`)
-  const wrapper = path.join(root, `${name}.cmd`)
   await writeFile(script, source, 'utf8')
-  await writeFile(wrapper, `@echo off\r\n"${process.execPath}" "%~dp0${name}.cjs" %*\r\n`, 'utf8')
-  return wrapper
+  return { dwsCommand: process.execPath, dwsArgsPrefix: [script] }
 }
 
 test('本地白名单分别覆盖 operator、额外私聊、群白名单和默认拒绝', () => {
@@ -76,7 +73,7 @@ test('本地白名单分别覆盖 operator、额外私聊、群白名单和默�
   )
 })
 
-async function createFakeDws(root) {
+async function createFakeDws(root, pathCommand = false) {
   const source = `#!/usr/bin/env node
 const fs = require('node:fs')
 const record = process.env.FAKE_DWS_RECORD
@@ -118,7 +115,7 @@ if (operation === 'consume') {
   })
 }
 `
-  return writeFakeDwsCommand(root, 'dws', source)
+  return writeFakeDwsCommand(root, 'dws', source, pathCommand)
 }
 
 async function createRetryFakeDws(root) {
@@ -308,7 +305,7 @@ test('fake DWS 验证 ready、半行/坏包隔离、白名单、去重、自回�
   const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-de-runtime-'))
   const stateDir = path.join(root, 'state')
   const recordFile = path.join(root, 'invocations.ndjson')
-  const dwsCommand = await createFakeDws(root)
+  const dwsInvocation = await createFakeDws(root)
   const originalRecord = process.env.FAKE_DWS_RECORD
   const originalToken = process.env.DWS_ACCESS_TOKEN
   let runtime
@@ -328,7 +325,7 @@ test('fake DWS 验证 ready、半行/坏包隔离、白名单、去重、自回�
   runtime = new DwsDigitalEmployeeSource({
     employee,
     stateDir,
-    dwsCommand,
+    ...dwsInvocation,
     readyTimeoutMs: 2_000,
     log: (line) => logs.push(line),
     onMessage: async (input) => {
@@ -419,7 +416,7 @@ test('ledger 损坏时隔离目标员工并持久化 doctor 可见的 fail-close
 
 test('启动失败严格执行 retryable=false/true/unknown 的 0/2/1 重试预算', async (t) => {
   const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-de-retry-'))
-  const command = await createRetryFakeDws(root)
+  const dwsInvocation = await createRetryFakeDws(root)
   const originalAttempt = process.env.FAKE_DWS_ATTEMPT_FILE
   const originalFailCount = process.env.FAKE_DWS_FAIL_COUNT
   const originalRetryable = process.env.FAKE_DWS_RETRYABLE
@@ -449,7 +446,7 @@ test('启动失败严格执行 retryable=false/true/unknown 的 0/2/1 重试预�
     const runtime = new DwsDigitalEmployeeSource({
       employee: { ...employee, agentUuid: `employee-retry-${scenario.hint}` },
       stateDir: path.join(root, `state-${scenario.hint}`),
-      dwsCommand: command,
+      ...dwsInvocation,
       readyTimeoutMs: 1_000,
       log: () => {},
       onMessage: () => {},
@@ -469,14 +466,14 @@ test('启动失败严格执行 retryable=false/true/unknown 的 0/2/1 重试预�
 
 test('ready 超时会等待旧订阅进程退出后再重试，不并行创建等价订阅', async (t) => {
   const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-de-no-overlap-'))
-  const command = await createSlowExitFakeDws(root)
+  const dwsInvocation = await createSlowExitFakeDws(root)
   const stateFile = path.join(root, 'subscription-state.json')
   const originalStateFile = process.env.FAKE_DWS_SUBSCRIPTION_STATE
   process.env.FAKE_DWS_SUBSCRIPTION_STATE = stateFile
   const runtime = new DwsDigitalEmployeeSource({
     employee: { ...employee, agentUuid: 'employee-no-overlap' },
     stateDir: path.join(root, 'state'),
-    dwsCommand: command,
+    ...dwsInvocation,
     readyTimeoutMs: 300,
     log: () => {},
     onMessage: () => {},
@@ -495,7 +492,7 @@ test('ready 超时会等待旧订阅进程退出后再重试，不并行创建�
 
 test('本地审计不可写时 fail-closed，不创建新 Agent 任务', async (t) => {
   const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-de-audit-fail-'))
-  const command = await createAuditFailFakeDws(root)
+  const dwsInvocation = await createAuditFailFakeDws(root)
   let runtime
   t.after(async () => {
     await runtime?.stop()
@@ -506,7 +503,7 @@ test('本地审计不可写时 fail-closed，不创建新 Agent 任务', async (
   runtime = new DwsDigitalEmployeeSource({
     employee: { ...employee, agentUuid: 'employee-audit-fail' },
     stateDir,
-    dwsCommand: command,
+    ...dwsInvocation,
     readyTimeoutMs: 1_000,
     log: () => {},
     onMessage: (input) => accepted.push(input),
@@ -577,67 +574,71 @@ test('白名单先于调度且不同会话不受长任务阻塞', async (t) => {
   assert.deepEqual(seen, ['ordinary-event', 'control-event'])
 })
 
-test('无机器人时启动两个数字员工，复用 Bridge/Queue/Session 并在重启后抑制重复回复', async (t) => {
-  const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-de-host-'))
-  const binDir = path.join(root, 'bin')
-  await writeFile(path.join(root, '.keep'), '')
-  await mkdir(binDir, { recursive: true })
-  const fake = await createFakeDws(binDir)
-  assert.equal(fake, path.join(binDir, process.platform === 'win32' ? 'dws.cmd' : 'dws'))
-  const recordFile = path.join(root, 'host-invocations.ndjson')
-  const stateDir = path.join(root, 'state')
-  const originalPath = process.env.PATH
-  const originalRecord = process.env.FAKE_DWS_RECORD
-  const originalState = process.env.DSH_DINGTALK_STATE_DIR
-  process.env.PATH = `${binDir}${path.delimiter}${originalPath ?? ''}`
-  process.env.FAKE_DWS_RECORD = recordFile
-  process.env.DSH_DINGTALK_STATE_DIR = stateDir
-  const hosts = []
-  t.after(async () => {
-    for (const host of hosts) host.dispose()
-    await new Promise((resolve) => setTimeout(resolve, 20))
-    if (originalPath === undefined) delete process.env.PATH
-    else process.env.PATH = originalPath
-    if (originalRecord === undefined) delete process.env.FAKE_DWS_RECORD
-    else process.env.FAKE_DWS_RECORD = originalRecord
-    if (originalState === undefined) delete process.env.DSH_DINGTALK_STATE_DIR
-    else process.env.DSH_DINGTALK_STATE_DIR = originalState
-    await rm(root, { recursive: true, force: true })
-  })
+test(
+  '无机器人时启动两个数字员工，复用 Bridge/Queue/Session 并在重启后抑制重复回复',
+  { skip: process.platform === 'win32' ? 'Windows PATH 测试不能安全执行脚本型 fake DWS' : false },
+  async (t) => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-de-host-'))
+    const binDir = path.join(root, 'bin')
+    await writeFile(path.join(root, '.keep'), '')
+    await mkdir(binDir, { recursive: true })
+    const fake = await createFakeDws(binDir, true)
+    assert.equal(fake.dwsCommand, path.join(binDir, 'dws'))
+    const recordFile = path.join(root, 'host-invocations.ndjson')
+    const stateDir = path.join(root, 'state')
+    const originalPath = process.env.PATH
+    const originalRecord = process.env.FAKE_DWS_RECORD
+    const originalState = process.env.DSH_DINGTALK_STATE_DIR
+    process.env.PATH = `${binDir}${path.delimiter}${originalPath ?? ''}`
+    process.env.FAKE_DWS_RECORD = recordFile
+    process.env.DSH_DINGTALK_STATE_DIR = stateDir
+    const hosts = []
+    t.after(async () => {
+      for (const host of hosts) host.dispose()
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      if (originalPath === undefined) delete process.env.PATH
+      else process.env.PATH = originalPath
+      if (originalRecord === undefined) delete process.env.FAKE_DWS_RECORD
+      else process.env.FAKE_DWS_RECORD = originalRecord
+      if (originalState === undefined) delete process.env.DSH_DINGTALK_STATE_DIR
+      else process.env.DSH_DINGTALK_STATE_DIR = originalState
+      await rm(root, { recursive: true, force: true })
+    })
 
-  const employees = [
-    employee,
-    { ...employee, agentUuid: 'employee-runtime-2', dwsProfile: 'corp-runtime:user-runtime-2' },
-  ]
-  const first = createHost()
-  hosts.push(first)
-  await apply(first.ctx, pluginConfig(path.join(root, 'workspace'), employees))
-  await waitFor(async () => {
-    try {
-      const records = (await readFile(recordFile, 'utf8'))
-        .trim()
-        .split('\n')
-        .map((line) => JSON.parse(line))
-      return first.followups.length === 2 && records.filter((item) => item.operation === 'reply').length === 2
-    } catch {
-      return false
-    }
-  })
-  assert.equal(new Set(first.followups.map((item) => item.sessionId)).size, 2)
-  assert.ok(first.followups.every((item) => item.message.content[0].text === '只应通过 stdin 回复的正文'))
+    const employees = [
+      employee,
+      { ...employee, agentUuid: 'employee-runtime-2', dwsProfile: 'corp-runtime:user-runtime-2' },
+    ]
+    const first = createHost()
+    hosts.push(first)
+    await apply(first.ctx, pluginConfig(path.join(root, 'workspace'), employees))
+    await waitFor(async () => {
+      try {
+        const records = (await readFile(recordFile, 'utf8'))
+          .trim()
+          .split('\n')
+          .map((line) => JSON.parse(line))
+        return first.followups.length === 2 && records.filter((item) => item.operation === 'reply').length === 2
+      } catch {
+        return false
+      }
+    })
+    assert.equal(new Set(first.followups.map((item) => item.sessionId)).size, 2)
+    assert.ok(first.followups.every((item) => item.message.content[0].text === '只应通过 stdin 回复的正文'))
 
-  first.dispose()
-  await new Promise((resolve) => setTimeout(resolve, 50))
-  const beforeRestart = (await readFile(recordFile, 'utf8'))
-    .split('\n')
-    .filter((line) => line.includes('"operation":"reply"')).length
-  const second = createHost()
-  hosts.push(second)
-  await apply(second.ctx, pluginConfig(path.join(root, 'workspace'), employees))
-  await new Promise((resolve) => setTimeout(resolve, 150))
-  const afterRestart = (await readFile(recordFile, 'utf8'))
-    .split('\n')
-    .filter((line) => line.includes('"operation":"reply"')).length
-  assert.equal(second.followups.length, 0)
-  assert.equal(afterRestart, beforeRestart)
-})
+    first.dispose()
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    const beforeRestart = (await readFile(recordFile, 'utf8'))
+      .split('\n')
+      .filter((line) => line.includes('"operation":"reply"')).length
+    const second = createHost()
+    hosts.push(second)
+    await apply(second.ctx, pluginConfig(path.join(root, 'workspace'), employees))
+    await new Promise((resolve) => setTimeout(resolve, 150))
+    const afterRestart = (await readFile(recordFile, 'utf8'))
+      .split('\n')
+      .filter((line) => line.includes('"operation":"reply"')).length
+    assert.equal(second.followups.length, 0)
+    assert.equal(afterRestart, beforeRestart)
+  },
+)

--- a/test/digital-employee-runtime.test.mjs
+++ b/test/digital-employee-runtime.test.mjs
@@ -67,21 +67,21 @@ async function createFakeDws(root) {
 const fs = require('node:fs')
 const record = process.env.FAKE_DWS_RECORD
 const args = process.argv.slice(2)
-const operation = args.includes('capabilities') ? 'capabilities' : args.includes('audit') ? 'audit' : args.includes('reply') ? 'reply' : args.includes('operator-private') ? 'operator-private' : args.includes('consume') ? 'consume' : 'unknown'
+const operation = args.includes('capabilities') ? 'capabilities' : args.includes('reply') ? 'reply' : args.includes('operator-private') ? 'operator-private' : args.includes('consume') ? 'consume' : 'unknown'
 fs.appendFileSync(record, JSON.stringify({ operation, args, credentialEnvKeys: Object.keys(process.env).filter((key) => /TOKEN|AUTH_?CODE|CLIENT_?SECRET|PASSWORD|CREDENTIAL/i.test(key)) }) + '\\n')
 if (operation === 'capabilities') {
-  process.stdout.write(JSON.stringify({ schemaVersion: 1, protocolVersion: 1, capabilities: { eventConsume: true, replyStdin: true, operatorPrivateStdin: true, auditStdin: true } }))
+  process.stdout.write(JSON.stringify({ ok: true, outcome: 'success', data: { schemaVersion: 1, protocolVersion: 1, auditMode: 'local_required', capabilities: { eventConsume: true, replyStdin: true, operatorPrivateStdin: true } }, meta: {} }))
   process.exit(0)
 }
 
 let input = ''
 if (operation === 'consume') {
-  process.stderr.write('[event] ready\\n')
+  process.stderr.write('[event] ready event_count=0 bus_pid=123\\n')
   const events = [
-    { schemaVersion: 1, eventId: 'event-allowed', messageId: 'message-allowed', conversationId: 'allowed-group', conversationType: 'group', senderOpenDingTalkId: 'allowed-open-id', senderName: '成员', text: '只应通过 stdin 回复的正文', createdAt: '1' },
-    { schemaVersion: 1, eventId: 'event-allowed', messageId: 'message-allowed', conversationId: 'allowed-group', conversationType: 'group', senderOpenDingTalkId: 'allowed-open-id', senderName: '成员', text: '重复正文', createdAt: '1' },
-    { schemaVersion: 1, eventId: 'event-denied', messageId: 'message-denied', conversationId: 'blocked-group', conversationType: 'group', senderOpenDingTalkId: 'intruder', senderName: '越权用户', text: '越权正文', createdAt: '2' },
-    { schemaVersion: 1, eventId: 'event-self', messageId: 'outgoing-1', conversationId: 'allowed-group', conversationType: 'group', senderOpenDingTalkId: 'employee-runtime-1', senderName: '数字员工', text: '自回复正文', createdAt: '3' },
+    { type: 'user_im_message_receive_group_all', event_id: 'event-allowed', message_id: 'message-allowed', conversation_id: 'allowed-group', sender_open_dingtalk_id: 'allowed-open-id', sender: '成员', content: '只应通过 stdin 回复的正文', event_time: '1' },
+    { type: 'user_im_message_receive_group_all', event_id: 'event-allowed', message_id: 'message-allowed', conversation_id: 'allowed-group', sender_open_dingtalk_id: 'allowed-open-id', sender: '成员', content: '重复正文', event_time: '1' },
+    { type: 'user_im_message_receive_group_all', event_id: 'event-denied', message_id: 'message-denied', conversation_id: 'blocked-group', sender_open_dingtalk_id: 'intruder', sender: '越权用户', content: '越权正文', create_time: '2' },
+    { type: 'user_im_message_receive_group_all', event_id: 'event-self', message_id: 'outgoing-1', conversation_id: 'allowed-group', sender_open_dingtalk_id: 'employee-runtime-1', sender: '数字员工', content: '自回复正文', timestamp: '3' },
   ]
   process.stdout.write('{bad json}\\n')
   const first = JSON.stringify(events[0])
@@ -100,8 +100,7 @@ if (operation === 'consume') {
   process.stdin.on('data', (chunk) => { input += chunk })
   process.stdin.on('end', () => {
     const value = input ? JSON.parse(input) : {}
-    if (operation === 'audit') process.stdout.write('{}')
-    else process.stdout.write(JSON.stringify({ openMessageId: operation === 'reply' ? 'outgoing-1' : 'operator-message-1', conversationId: value.conversationId || 'operator-conversation', deliveryStatus: 'delivered', idempotencyKey: value.idempotencyKey }))
+    process.stdout.write(JSON.stringify({ ok: true, outcome: 'success', data: { openMessageId: operation === 'reply' ? 'outgoing-1' : 'operator-message-1', conversationId: value.conversationId || 'operator-conversation', deliveryStatus: 'delivered', idempotencyKey: value.idempotencyKey }, meta: {} }))
   })
 }
 `
@@ -116,13 +115,10 @@ async function createRetryFakeDws(root) {
 const fs = require('node:fs')
 const args = process.argv.slice(2)
 if (args.includes('capabilities')) {
-  process.stdout.write(JSON.stringify({ schemaVersion: 1, protocolVersion: 1, capabilities: { eventConsume: true, replyStdin: true, operatorPrivateStdin: true, auditStdin: true } }))
+  process.stdout.write(JSON.stringify({ ok: true, outcome: 'success', data: { schemaVersion: 1, protocolVersion: 1, auditMode: 'local_required', capabilities: { eventConsume: true, replyStdin: true, operatorPrivateStdin: true } }, meta: {} }))
   process.exit(0)
 }
-if (args.includes('audit')) {
-  process.stdin.resume()
-  process.stdin.on('end', () => process.stdout.write('{}'))
-} else if (args.includes('consume')) {
+if (args.includes('consume')) {
   const file = process.env.FAKE_DWS_ATTEMPT_FILE
   let count = 0
   try { count = Number(fs.readFileSync(file, 'utf8')) || 0 } catch {}
@@ -133,7 +129,7 @@ if (args.includes('audit')) {
     if (process.env.FAKE_DWS_RETRYABLE !== 'unknown') process.stderr.write('retryable=' + process.env.FAKE_DWS_RETRYABLE + '\\n')
     process.exit(1)
   }
-  process.stderr.write('[event] ready\\n')
+  process.stderr.write('[event] ready event_count=0\\n')
   process.stdin.resume()
   process.stdin.on('end', () => process.exit(0))
   process.on('SIGTERM', () => process.exit(0))
@@ -147,27 +143,15 @@ if (args.includes('audit')) {
 async function createAuditFailFakeDws(root) {
   const command = path.join(root, 'dws-audit-fail')
   const source = `#!/usr/bin/env node
-const fs = require('node:fs')
 const args = process.argv.slice(2)
 if (args.includes('capabilities')) {
-  process.stdout.write(JSON.stringify({ schemaVersion: 1, protocolVersion: 1, capabilities: { eventConsume: true, replyStdin: true, operatorPrivateStdin: true, auditStdin: true } }))
+  process.stdout.write(JSON.stringify({ ok: true, outcome: 'success', data: { schemaVersion: 1, protocolVersion: 1, auditMode: 'local_required', capabilities: { eventConsume: true, replyStdin: true, operatorPrivateStdin: true } }, meta: {} }))
   process.exit(0)
 }
 
-if (args.includes('audit')) {
-  process.stdin.resume()
-  process.stdin.on('end', () => {
-    const file = process.env.FAKE_DWS_AUDIT_COUNT_FILE
-    let count = 0
-    try { count = Number(fs.readFileSync(file, 'utf8')) || 0 } catch {}
-    count++
-    fs.writeFileSync(file, String(count))
-    if (count > 1) process.exit(1)
-    process.stdout.write('{}')
-  })
-} else if (args.includes('consume')) {
-  process.stderr.write('[event] ready\\n')
-  process.stdout.write(JSON.stringify({ schemaVersion: 1, eventId: 'audit-blocked-event', messageId: 'audit-blocked-message', conversationId: 'allowed-group', conversationType: 'group', senderOpenDingTalkId: 'allowed-open-id', senderName: '成员', text: '不得进入 Agent 的正文', createdAt: '1' }) + '\\n')
+if (args.includes('consume')) {
+  process.stderr.write('[event] ready event_count=0\\n')
+  process.stdout.write(JSON.stringify({ type: 'user_im_message_receive_group_all', event_id: 'audit-blocked-event', message_id: 'audit-blocked-message', conversation_id: 'allowed-group', sender_open_dingtalk_id: 'allowed-open-id', sender: '成员', content: '不得进入 Agent 的正文', event_time: '1' }) + '\\n')
   process.stdin.resume()
   process.stdin.on('end', () => process.exit(0))
   process.on('SIGTERM', () => process.exit(0))
@@ -187,13 +171,10 @@ const file = process.env.FAKE_DWS_SUBSCRIPTION_STATE
 const readState = () => { try { return JSON.parse(fs.readFileSync(file, 'utf8')) } catch { return { attempts: 0, active: 0, maxActive: 0 } } }
 const writeState = (state) => fs.writeFileSync(file, JSON.stringify(state))
 if (args.includes('capabilities')) {
-  process.stdout.write(JSON.stringify({ schemaVersion: 1, protocolVersion: 1, capabilities: { eventConsume: true, replyStdin: true, operatorPrivateStdin: true, auditStdin: true } }))
+  process.stdout.write(JSON.stringify({ ok: true, outcome: 'success', data: { schemaVersion: 1, protocolVersion: 1, auditMode: 'local_required', capabilities: { eventConsume: true, replyStdin: true, operatorPrivateStdin: true } }, meta: {} }))
   process.exit(0)
 }
-if (args.includes('audit')) {
-  process.stdin.resume()
-  process.stdin.on('end', () => process.stdout.write('{}'))
-} else if (args.includes('consume')) {
+if (args.includes('consume')) {
   const state = readState()
   state.attempts++
   state.active++
@@ -211,7 +192,7 @@ if (args.includes('audit')) {
     process.stdin.on('end', () => {})
     process.on('SIGTERM', () => setTimeout(() => { clearInterval(hold); finish() }, 100))
   } else {
-    process.stderr.write('[event] ready\\n')
+    process.stderr.write('[event] ready bus_pid=456\\n')
     process.stdin.on('end', finish)
     process.on('SIGTERM', finish)
   }
@@ -381,11 +362,25 @@ test('fake DWS 验证 ready、半行/坏包隔离、白名单、去重、自回�
   assert.ok(records.every((item) => item.credentialEnvKeys.length === 0))
   assert.doesNotMatch(JSON.stringify(records), /回复正文|越权正文|自回复正文|must-not-reach-child/)
   assert.equal(records.filter((item) => item.operation === 'reply').length, 1)
+  const reply = records.find((item) => item.operation === 'reply')
+  assert.deepEqual(reply.args.slice(2), [
+    'dingtalk-tag',
+    'channel',
+    'reply',
+    '--channel',
+    'dsh',
+    '--stdin',
+    '--format',
+    'json',
+  ])
 
   assert.equal((await stat(stateDir)).mode & 0o777, 0o700)
   assert.equal((await stat(path.join(stateDir, 'ledger.json'))).mode & 0o777, 0o600)
   assert.equal((await stat(path.join(stateDir, 'runtime.json'))).mode & 0o777, 0o600)
+  assert.equal((await stat(path.join(stateDir, 'audit'))).mode & 0o777, 0o700)
+  assert.equal((await stat(path.join(stateDir, 'audit', 'employee-runtime-1.jsonl'))).mode & 0o777, 0o600)
   assert.doesNotMatch(await readFile(path.join(stateDir, 'ledger.json'), 'utf8'), /正文/)
+  assert.doesNotMatch(await readFile(path.join(stateDir, 'audit', 'employee-runtime-1.jsonl'), 'utf8'), /正文/)
 
   await runtime.stop()
   assert.equal(runtime.currentStatus().state, 'stopped')
@@ -491,42 +486,29 @@ test('ready 超时会等待旧订阅进程退出后再重试，不并行创建�
   assert.deepEqual(state, { attempts: 2, active: 1, maxActive: 1 })
 })
 
-test('远程审计中断时 fail-closed，不创建新 Agent 任务', async (t) => {
+test('本地审计不可写时 fail-closed，不创建新 Agent 任务', async (t) => {
   const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-de-audit-fail-'))
   const command = await createAuditFailFakeDws(root)
-  const countFile = path.join(root, 'audit-count')
-  const originalCountFile = process.env.FAKE_DWS_AUDIT_COUNT_FILE
-  process.env.FAKE_DWS_AUDIT_COUNT_FILE = countFile
   let runtime
   t.after(async () => {
     await runtime?.stop()
-    if (originalCountFile === undefined) delete process.env.FAKE_DWS_AUDIT_COUNT_FILE
-    else process.env.FAKE_DWS_AUDIT_COUNT_FILE = originalCountFile
     await rm(root, { recursive: true, force: true })
   })
   const accepted = []
-  const logs = []
+  const stateDir = path.join(root, 'state')
   runtime = new DwsDigitalEmployeeSource({
     employee: { ...employee, agentUuid: 'employee-audit-fail' },
-    stateDir: path.join(root, 'state'),
+    stateDir,
     dwsCommand: command,
     readyTimeoutMs: 1_000,
-    log: (line) => logs.push(line),
+    log: () => {},
     onMessage: (input) => accepted.push(input),
   })
+  await writeFile(path.join(stateDir, 'audit'), '阻止创建审计目录', 'utf8')
 
-  await runtime.start()
-  await waitFor(async () => {
-    try {
-      return Number(await readFile(countFile, 'utf8')) >= 2
-    } catch {
-      return false
-    }
-  })
-  await new Promise((resolve) => setTimeout(resolve, 20))
+  await assert.rejects(() => runtime.start())
   assert.equal(accepted.length, 0)
   assert.equal(runtime.currentStatus().failureCode, 'audit_unavailable')
-  assert.ok(logs.some((line) => line.includes('event rejected (dws_exit_1)')))
 })
 
 test('白名单先于调度且不同会话不受长任务阻塞', async (t) => {

--- a/test/digital-employee-runtime.test.mjs
+++ b/test/digital-employee-runtime.test.mjs
@@ -1,0 +1,654 @@
+import assert from 'node:assert/strict'
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import { authorizeDigitalEmployeeEvent, DwsDigitalEmployeeSource } from '../lib/digital-employee-runtime.js'
+import { apply } from '../lib/index.js'
+
+async function waitFor(check) {
+  for (let attempt = 0; attempt < 200; attempt++) {
+    if (await check()) return
+    await new Promise((resolve) => setTimeout(resolve, 5))
+  }
+  assert.fail('等待 fake DWS 运行时行为超时')
+}
+
+const employee = {
+  agentUuid: 'employee-runtime-1',
+  name: '值班助手',
+  enabled: true,
+  dwsProfile: 'corp-runtime:user-runtime',
+  operatorOpenDingTalkId: 'operator-open-id',
+  allowedDirectSenders: ['allowed-open-id'],
+  allowedGroups: ['allowed-group'],
+  sessionScope: 'chat-sender',
+  protocolVersion: 1,
+}
+
+test('本地白名单分别覆盖 operator、额外私聊、群白名单和默认拒绝', () => {
+  const base = {
+    schemaVersion: 1,
+    eventId: 'access-event',
+    messageId: 'access-message',
+    conversationId: 'direct-conversation',
+    conversationType: 'direct',
+    senderOpenDingTalkId: 'operator-open-id',
+    senderName: '用户',
+    text: '正文',
+    createdAt: '1',
+  }
+  assert.equal(authorizeDigitalEmployeeEvent(employee, base), true)
+  assert.equal(authorizeDigitalEmployeeEvent(employee, { ...base, senderOpenDingTalkId: 'allowed-open-id' }), true)
+  assert.equal(authorizeDigitalEmployeeEvent(employee, { ...base, senderOpenDingTalkId: 'intruder' }), false)
+  assert.equal(
+    authorizeDigitalEmployeeEvent(employee, {
+      ...base,
+      conversationType: 'group',
+      conversationId: 'allowed-group',
+      senderOpenDingTalkId: 'intruder',
+    }),
+    true,
+  )
+  assert.equal(
+    authorizeDigitalEmployeeEvent(employee, {
+      ...base,
+      conversationType: 'group',
+      conversationId: 'blocked-group',
+    }),
+    false,
+  )
+})
+
+async function createFakeDws(root) {
+  const command = path.join(root, 'dws')
+  const source = `#!/usr/bin/env node
+const fs = require('node:fs')
+const record = process.env.FAKE_DWS_RECORD
+const args = process.argv.slice(2)
+const operation = args.includes('capabilities') ? 'capabilities' : args.includes('audit') ? 'audit' : args.includes('reply') ? 'reply' : args.includes('operator-private') ? 'operator-private' : args.includes('consume') ? 'consume' : 'unknown'
+fs.appendFileSync(record, JSON.stringify({ operation, args, credentialEnvKeys: Object.keys(process.env).filter((key) => /TOKEN|AUTH_?CODE|CLIENT_?SECRET|PASSWORD|CREDENTIAL/i.test(key)) }) + '\\n')
+if (operation === 'capabilities') {
+  process.stdout.write(JSON.stringify({ schemaVersion: 1, protocolVersion: 1, capabilities: { eventConsume: true, replyStdin: true, operatorPrivateStdin: true, auditStdin: true } }))
+  process.exit(0)
+}
+
+let input = ''
+if (operation === 'consume') {
+  process.stderr.write('[event] ready\\n')
+  const events = [
+    { schemaVersion: 1, eventId: 'event-allowed', messageId: 'message-allowed', conversationId: 'allowed-group', conversationType: 'group', senderOpenDingTalkId: 'allowed-open-id', senderName: '成员', text: '只应通过 stdin 回复的正文', createdAt: '1' },
+    { schemaVersion: 1, eventId: 'event-allowed', messageId: 'message-allowed', conversationId: 'allowed-group', conversationType: 'group', senderOpenDingTalkId: 'allowed-open-id', senderName: '成员', text: '重复正文', createdAt: '1' },
+    { schemaVersion: 1, eventId: 'event-denied', messageId: 'message-denied', conversationId: 'blocked-group', conversationType: 'group', senderOpenDingTalkId: 'intruder', senderName: '越权用户', text: '越权正文', createdAt: '2' },
+    { schemaVersion: 1, eventId: 'event-self', messageId: 'outgoing-1', conversationId: 'allowed-group', conversationType: 'group', senderOpenDingTalkId: 'employee-runtime-1', senderName: '数字员工', text: '自回复正文', createdAt: '3' },
+  ]
+  process.stdout.write('{bad json}\\n')
+  const first = JSON.stringify(events[0])
+  process.stdout.write(first.slice(0, 20))
+  setTimeout(() => {
+    process.stdout.write(first.slice(20) + '\\n')
+    process.stdout.write(JSON.stringify(events[1]) + '\\n')
+    process.stdout.write(JSON.stringify(events[2]) + '\\n')
+    setTimeout(() => process.stdout.write(JSON.stringify(events[3]) + '\\n'), 50)
+  }, 10)
+  process.stdin.resume()
+  process.stdin.on('end', () => process.exit(0))
+  process.on('SIGTERM', () => process.exit(0))
+} else {
+  process.stdin.setEncoding('utf8')
+  process.stdin.on('data', (chunk) => { input += chunk })
+  process.stdin.on('end', () => {
+    const value = input ? JSON.parse(input) : {}
+    if (operation === 'audit') process.stdout.write('{}')
+    else process.stdout.write(JSON.stringify({ openMessageId: operation === 'reply' ? 'outgoing-1' : 'operator-message-1', conversationId: value.conversationId || 'operator-conversation', deliveryStatus: 'delivered', idempotencyKey: value.idempotencyKey }))
+  })
+}
+`
+  await writeFile(command, source, { mode: 0o755 })
+  await chmod(command, 0o755)
+  return command
+}
+
+async function createRetryFakeDws(root) {
+  const command = path.join(root, 'dws-retry')
+  const source = `#!/usr/bin/env node
+const fs = require('node:fs')
+const args = process.argv.slice(2)
+if (args.includes('capabilities')) {
+  process.stdout.write(JSON.stringify({ schemaVersion: 1, protocolVersion: 1, capabilities: { eventConsume: true, replyStdin: true, operatorPrivateStdin: true, auditStdin: true } }))
+  process.exit(0)
+}
+if (args.includes('audit')) {
+  process.stdin.resume()
+  process.stdin.on('end', () => process.stdout.write('{}'))
+} else if (args.includes('consume')) {
+  const file = process.env.FAKE_DWS_ATTEMPT_FILE
+  let count = 0
+  try { count = Number(fs.readFileSync(file, 'utf8')) || 0 } catch {}
+  count++
+  fs.writeFileSync(file, String(count))
+  const failCount = Number(process.env.FAKE_DWS_FAIL_COUNT)
+  if (count <= failCount) {
+    if (process.env.FAKE_DWS_RETRYABLE !== 'unknown') process.stderr.write('retryable=' + process.env.FAKE_DWS_RETRYABLE + '\\n')
+    process.exit(1)
+  }
+  process.stderr.write('[event] ready\\n')
+  process.stdin.resume()
+  process.stdin.on('end', () => process.exit(0))
+  process.on('SIGTERM', () => process.exit(0))
+}
+`
+  await writeFile(command, source, { mode: 0o755 })
+  await chmod(command, 0o755)
+  return command
+}
+
+async function createAuditFailFakeDws(root) {
+  const command = path.join(root, 'dws-audit-fail')
+  const source = `#!/usr/bin/env node
+const fs = require('node:fs')
+const args = process.argv.slice(2)
+if (args.includes('capabilities')) {
+  process.stdout.write(JSON.stringify({ schemaVersion: 1, protocolVersion: 1, capabilities: { eventConsume: true, replyStdin: true, operatorPrivateStdin: true, auditStdin: true } }))
+  process.exit(0)
+}
+
+if (args.includes('audit')) {
+  process.stdin.resume()
+  process.stdin.on('end', () => {
+    const file = process.env.FAKE_DWS_AUDIT_COUNT_FILE
+    let count = 0
+    try { count = Number(fs.readFileSync(file, 'utf8')) || 0 } catch {}
+    count++
+    fs.writeFileSync(file, String(count))
+    if (count > 1) process.exit(1)
+    process.stdout.write('{}')
+  })
+} else if (args.includes('consume')) {
+  process.stderr.write('[event] ready\\n')
+  process.stdout.write(JSON.stringify({ schemaVersion: 1, eventId: 'audit-blocked-event', messageId: 'audit-blocked-message', conversationId: 'allowed-group', conversationType: 'group', senderOpenDingTalkId: 'allowed-open-id', senderName: '成员', text: '不得进入 Agent 的正文', createdAt: '1' }) + '\\n')
+  process.stdin.resume()
+  process.stdin.on('end', () => process.exit(0))
+  process.on('SIGTERM', () => process.exit(0))
+}
+`
+  await writeFile(command, source, { mode: 0o755 })
+  await chmod(command, 0o755)
+  return command
+}
+
+async function createSlowExitFakeDws(root) {
+  const command = path.join(root, 'dws-slow-exit')
+  const source = `#!/usr/bin/env node
+const fs = require('node:fs')
+const args = process.argv.slice(2)
+const file = process.env.FAKE_DWS_SUBSCRIPTION_STATE
+const readState = () => { try { return JSON.parse(fs.readFileSync(file, 'utf8')) } catch { return { attempts: 0, active: 0, maxActive: 0 } } }
+const writeState = (state) => fs.writeFileSync(file, JSON.stringify(state))
+if (args.includes('capabilities')) {
+  process.stdout.write(JSON.stringify({ schemaVersion: 1, protocolVersion: 1, capabilities: { eventConsume: true, replyStdin: true, operatorPrivateStdin: true, auditStdin: true } }))
+  process.exit(0)
+}
+if (args.includes('audit')) {
+  process.stdin.resume()
+  process.stdin.on('end', () => process.stdout.write('{}'))
+} else if (args.includes('consume')) {
+  const state = readState()
+  state.attempts++
+  state.active++
+  state.maxActive = Math.max(state.maxActive, state.active)
+  writeState(state)
+  const finish = () => {
+    const latest = readState()
+    latest.active--
+    writeState(latest)
+    process.exit(0)
+  }
+  process.stdin.resume()
+  if (state.attempts === 1) {
+    const hold = setInterval(() => {}, 1000)
+    process.stdin.on('end', () => {})
+    process.on('SIGTERM', () => setTimeout(() => { clearInterval(hold); finish() }, 100))
+  } else {
+    process.stderr.write('[event] ready\\n')
+    process.stdin.on('end', finish)
+    process.on('SIGTERM', finish)
+  }
+}
+`
+  await writeFile(command, source, { mode: 0o755 })
+  await chmod(command, 0o755)
+  return command
+}
+
+function createHost() {
+  const handlers = new Map()
+  const agents = new Map()
+  const followups = []
+  const sessions = []
+  const emit = (name, ...args) => {
+    for (const handler of handlers.get(name) ?? []) handler(...args)
+  }
+  const ctx = {
+    credentials: { resolve: async () => undefined },
+    agentDefaultModel: { currentSelection: () => ({ provider: 'test', model: 'model' }) },
+    agents: {
+      get: (id) => agents.get(id),
+      resume: async () => {
+        throw new Error('restart test deliberately has no live agent')
+      },
+      create: async (options) => {
+        const scoped = new Map()
+        const agentCtx = {
+          agent: undefined,
+          tools: { register: () => () => {} },
+          on(name, handler) {
+            scoped.set(name, handler)
+            return () => scoped.delete(name)
+          },
+        }
+        const agent = {
+          id: options.sessionId,
+          status: 'idle',
+          ctx: agentCtx,
+          followup(message) {
+            followups.push({ sessionId: options.sessionId, message })
+            queueMicrotask(() => {
+              emit(
+                'session/event',
+                { id: options.sessionId },
+                { type: 'assistant/message', data: { message: { content: [{ type: 'text', text: '已处理' }] } } },
+              )
+              emit('session/event', { id: options.sessionId }, { type: 'turn/end', data: { reason: {} } })
+            })
+          },
+          steer() {},
+          cancel() {},
+        }
+        agentCtx.agent = agent
+        await options.setup?.(agentCtx)
+        agents.set(options.sessionId, agent)
+        sessions.push({ sessionId: options.sessionId, scoped })
+        return { agent, dispose: async () => {} }
+      },
+    },
+    get(name) {
+      if (name !== 'workspaceRegistry') return undefined
+      return {
+        resolveByPath: async () => ({ path: '/test-workspace', sessionIds: [], attachSession: async () => {} }),
+        create: async (workspace) => ({ path: workspace, sessionIds: [], attachSession: async () => {} }),
+      }
+    },
+    on(name, handler) {
+      const list = handlers.get(name) ?? []
+      list.push(handler)
+      handlers.set(name, list)
+      return () => list.splice(list.indexOf(handler), 1)
+    },
+  }
+  return { ctx, followups, sessions, dispose: () => emit('dispose') }
+}
+
+function pluginConfig(workspace, digitalEmployees) {
+  return {
+    accounts: [],
+    digitalEmployees,
+    clientId: '',
+    clientSecret: '',
+    workspace,
+    markdownTitle: 'DSH',
+    interactionCardTemplateId: '',
+    ownerStaffId: '',
+    senderAccess: 'owner',
+    allowedSenders: [],
+    groupAccess: 'none',
+    groupAllowlist: [],
+    replyMode: { direct: 'text', group: 'text' },
+    streaming: { enabled: false, throttleMs: 500, maxCardChars: 15_000 },
+    asyncMode: false,
+    ackText: '处理中',
+    queueAckText: '排队中',
+    questionTimeoutMs: 10_000,
+    approvalTimeoutMs: 10_000,
+    tools: { enabled: false },
+    sessionScope: 'chat',
+    imageMode: 'never',
+    emotionFirstResponse: false,
+    rejectNotice: false,
+    debug: false,
+  }
+}
+
+test('fake DWS 验证 ready、半行/坏包隔离、白名单、去重、自回复 ledger 和安全 stdin', async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-de-runtime-'))
+  const stateDir = path.join(root, 'state')
+  const recordFile = path.join(root, 'invocations.ndjson')
+  const dwsCommand = await createFakeDws(root)
+  const originalRecord = process.env.FAKE_DWS_RECORD
+  const originalToken = process.env.DWS_ACCESS_TOKEN
+  let runtime
+  process.env.FAKE_DWS_RECORD = recordFile
+  process.env.DWS_ACCESS_TOKEN = 'must-not-reach-child'
+  t.after(async () => {
+    await runtime?.stop()
+    if (originalRecord === undefined) delete process.env.FAKE_DWS_RECORD
+    else process.env.FAKE_DWS_RECORD = originalRecord
+    if (originalToken === undefined) delete process.env.DWS_ACCESS_TOKEN
+    else process.env.DWS_ACCESS_TOKEN = originalToken
+    await rm(root, { recursive: true, force: true })
+  })
+
+  const accepted = []
+  const logs = []
+  runtime = new DwsDigitalEmployeeSource({
+    employee,
+    stateDir,
+    dwsCommand,
+    readyTimeoutMs: 2_000,
+    log: (line) => logs.push(line),
+    onMessage: async (input) => {
+      accepted.push(input)
+      await runtime.replySink.reply(input.event, 'session-safe-id', '回复正文只能进入 stdin')
+    },
+  })
+  await runtime.start()
+  await waitFor(() => accepted.length === 1 && runtime.currentStatus().lastReplyAt)
+  await new Promise((resolve) => setTimeout(resolve, 100))
+
+  assert.equal(runtime.currentStatus().state, 'ready')
+  assert.equal(accepted.length, 1)
+  assert.equal(accepted[0].scopeKey, 'employee-runtime-1:allowed-group#allowed-open-id')
+  assert.equal(accepted[0].message.text, '只应通过 stdin 回复的正文')
+  assert.ok(logs.includes('event parse rejected (invalid_json)'))
+
+  const records = (await readFile(recordFile, 'utf8'))
+    .trim()
+    .split('\n')
+    .map((line) => JSON.parse(line))
+  const consumer = records.find((item) => item.operation === 'consume')
+  assert.deepEqual(consumer.args, [
+    '--profile',
+    'corp-runtime:user-runtime',
+    'event',
+    'consume',
+    'user_im_message_receive_o2o_all',
+    'user_im_message_receive_group_all',
+    '--flatten',
+    '--format',
+    'ndjson',
+  ])
+  assert.ok(records.every((item) => item.credentialEnvKeys.length === 0))
+  assert.doesNotMatch(JSON.stringify(records), /回复正文|越权正文|自回复正文|must-not-reach-child/)
+  assert.equal(records.filter((item) => item.operation === 'reply').length, 1)
+
+  assert.equal((await stat(stateDir)).mode & 0o777, 0o700)
+  assert.equal((await stat(path.join(stateDir, 'ledger.json'))).mode & 0o777, 0o600)
+  assert.equal((await stat(path.join(stateDir, 'runtime.json'))).mode & 0o777, 0o600)
+  assert.doesNotMatch(await readFile(path.join(stateDir, 'ledger.json'), 'utf8'), /正文/)
+
+  await runtime.stop()
+  assert.equal(runtime.currentStatus().state, 'stopped')
+})
+
+test('ledger 损坏时隔离目标员工并持久化 doctor 可见的 fail-closed 状态', async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-de-corrupt-ledger-'))
+  const stateDir = path.join(root, 'state')
+  t.after(() => rm(root, { recursive: true, force: true }))
+  await mkdir(stateDir, { recursive: true })
+  await writeFile(path.join(stateDir, 'ledger.json'), '{not-json', 'utf8')
+
+  assert.throws(
+    () =>
+      new DwsDigitalEmployeeSource({
+        employee,
+        stateDir,
+        dwsCommand: '/must/not/run/dws',
+        log() {},
+        onMessage() {},
+      }),
+    /digital_employee_ledger_corrupt/,
+  )
+  const status = JSON.parse(await readFile(path.join(stateDir, 'runtime.json'), 'utf8'))
+  assert.equal(status.state, 'failed')
+  assert.equal(status.failureCode, 'ledger_corrupt')
+  assert.equal((await stat(path.join(stateDir, 'runtime.json'))).mode & 0o777, 0o600)
+})
+
+test('启动失败严格执行 retryable=false/true/unknown 的 0/2/1 重试预算', async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-de-retry-'))
+  const command = await createRetryFakeDws(root)
+  const originalAttempt = process.env.FAKE_DWS_ATTEMPT_FILE
+  const originalFailCount = process.env.FAKE_DWS_FAIL_COUNT
+  const originalRetryable = process.env.FAKE_DWS_RETRYABLE
+  const runtimes = []
+  t.after(async () => {
+    await Promise.all(runtimes.map((runtime) => runtime.stop()))
+    for (const [key, value] of [
+      ['FAKE_DWS_ATTEMPT_FILE', originalAttempt],
+      ['FAKE_DWS_FAIL_COUNT', originalFailCount],
+      ['FAKE_DWS_RETRYABLE', originalRetryable],
+    ]) {
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
+    }
+    await rm(root, { recursive: true, force: true })
+  })
+
+  for (const scenario of [
+    { hint: 'true', failures: 2, expectedAttempts: 3, succeeds: true },
+    { hint: 'unknown', failures: 1, expectedAttempts: 2, succeeds: true },
+    { hint: 'false', failures: 1, expectedAttempts: 1, succeeds: false },
+  ]) {
+    const attemptFile = path.join(root, `attempt-${scenario.hint}`)
+    process.env.FAKE_DWS_ATTEMPT_FILE = attemptFile
+    process.env.FAKE_DWS_FAIL_COUNT = String(scenario.failures)
+    process.env.FAKE_DWS_RETRYABLE = scenario.hint
+    const runtime = new DwsDigitalEmployeeSource({
+      employee: { ...employee, agentUuid: `employee-retry-${scenario.hint}` },
+      stateDir: path.join(root, `state-${scenario.hint}`),
+      dwsCommand: command,
+      readyTimeoutMs: 1_000,
+      log: () => {},
+      onMessage: () => {},
+    })
+    runtimes.push(runtime)
+    if (scenario.succeeds) {
+      await runtime.start()
+      assert.equal(runtime.currentStatus().state, 'ready')
+    } else {
+      await assert.rejects(() => runtime.start(), /event_consumer_exited_before_ready/)
+      assert.equal(runtime.currentStatus().state, 'failed')
+    }
+    assert.equal(Number(await readFile(attemptFile, 'utf8')), scenario.expectedAttempts)
+    await runtime.stop()
+  }
+})
+
+test('ready 超时会等待旧订阅进程退出后再重试，不并行创建等价订阅', async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-de-no-overlap-'))
+  const command = await createSlowExitFakeDws(root)
+  const stateFile = path.join(root, 'subscription-state.json')
+  const originalStateFile = process.env.FAKE_DWS_SUBSCRIPTION_STATE
+  process.env.FAKE_DWS_SUBSCRIPTION_STATE = stateFile
+  const runtime = new DwsDigitalEmployeeSource({
+    employee: { ...employee, agentUuid: 'employee-no-overlap' },
+    stateDir: path.join(root, 'state'),
+    dwsCommand: command,
+    readyTimeoutMs: 300,
+    log: () => {},
+    onMessage: () => {},
+  })
+  t.after(async () => {
+    await runtime.stop()
+    if (originalStateFile === undefined) delete process.env.FAKE_DWS_SUBSCRIPTION_STATE
+    else process.env.FAKE_DWS_SUBSCRIPTION_STATE = originalStateFile
+    await rm(root, { recursive: true, force: true })
+  })
+
+  await runtime.start()
+  const state = JSON.parse(await readFile(stateFile, 'utf8'))
+  assert.deepEqual(state, { attempts: 2, active: 1, maxActive: 1 })
+})
+
+test('远程审计中断时 fail-closed，不创建新 Agent 任务', async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-de-audit-fail-'))
+  const command = await createAuditFailFakeDws(root)
+  const countFile = path.join(root, 'audit-count')
+  const originalCountFile = process.env.FAKE_DWS_AUDIT_COUNT_FILE
+  process.env.FAKE_DWS_AUDIT_COUNT_FILE = countFile
+  let runtime
+  t.after(async () => {
+    await runtime?.stop()
+    if (originalCountFile === undefined) delete process.env.FAKE_DWS_AUDIT_COUNT_FILE
+    else process.env.FAKE_DWS_AUDIT_COUNT_FILE = originalCountFile
+    await rm(root, { recursive: true, force: true })
+  })
+  const accepted = []
+  const logs = []
+  runtime = new DwsDigitalEmployeeSource({
+    employee: { ...employee, agentUuid: 'employee-audit-fail' },
+    stateDir: path.join(root, 'state'),
+    dwsCommand: command,
+    readyTimeoutMs: 1_000,
+    log: (line) => logs.push(line),
+    onMessage: (input) => accepted.push(input),
+  })
+
+  await runtime.start()
+  await waitFor(async () => {
+    try {
+      return Number(await readFile(countFile, 'utf8')) >= 2
+    } catch {
+      return false
+    }
+  })
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  assert.equal(accepted.length, 0)
+  assert.equal(runtime.currentStatus().failureCode, 'audit_unavailable')
+  assert.ok(logs.some((line) => line.includes('event rejected (dws_exit_1)')))
+})
+
+test('白名单先于调度且不同会话不受长任务阻塞', async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-de-control-'))
+  let releaseTask
+  const task = new Promise((resolve) => {
+    releaseTask = resolve
+  })
+  const seen = []
+  const audits = []
+  const runtime = new DwsDigitalEmployeeSource({
+    employee,
+    stateDir: path.join(root, 'state'),
+    log: () => {},
+    onMessage: async (input) => {
+      seen.push(input.event.eventId)
+      if (input.event.eventId === 'control-event') releaseTask()
+      else await task
+    },
+  })
+  runtime.replySink.audit = async (fields) => audits.push(fields)
+  t.after(async () => {
+    releaseTask()
+    await runtime.stop()
+    await rm(root, { recursive: true, force: true })
+  })
+  const ordinary = {
+    schemaVersion: 1,
+    eventId: 'ordinary-event',
+    messageId: 'ordinary-message',
+    conversationId: 'allowed-group',
+    conversationType: 'group',
+    senderOpenDingTalkId: 'allowed-open-id',
+    senderName: '成员',
+    text: '触发等待审批的任务',
+    createdAt: '1',
+  }
+  const control = {
+    ...ordinary,
+    eventId: 'control-event',
+    messageId: 'control-message',
+    conversationId: 'operator-conversation',
+    conversationType: 'direct',
+    senderOpenDingTalkId: 'operator-open-id',
+    text: '确认 ABC123',
+  }
+  const denied = {
+    ...ordinary,
+    eventId: 'denied-event',
+    messageId: 'denied-message',
+    conversationId: 'blocked-group',
+  }
+
+  await runtime.handleEvent(ordinary)
+  await runtime.handleEvent(denied)
+  assert.ok(audits.some((item) => item.eventId === 'denied-event' && item.status === 'denied'))
+  await runtime.handleEvent(control)
+  await waitFor(() => seen.length === 2)
+  assert.deepEqual(seen, ['ordinary-event', 'control-event'])
+})
+
+test('无机器人时启动两个数字员工，复用 Bridge/Queue/Session 并在重启后抑制重复回复', async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-de-host-'))
+  const binDir = path.join(root, 'bin')
+  await writeFile(path.join(root, '.keep'), '')
+  await mkdir(binDir, { recursive: true })
+  const fake = await createFakeDws(binDir)
+  assert.equal(fake, path.join(binDir, 'dws'))
+  const recordFile = path.join(root, 'host-invocations.ndjson')
+  const stateDir = path.join(root, 'state')
+  const originalPath = process.env.PATH
+  const originalRecord = process.env.FAKE_DWS_RECORD
+  const originalState = process.env.DSH_DINGTALK_STATE_DIR
+  process.env.PATH = `${binDir}${path.delimiter}${originalPath ?? ''}`
+  process.env.FAKE_DWS_RECORD = recordFile
+  process.env.DSH_DINGTALK_STATE_DIR = stateDir
+  const hosts = []
+  t.after(async () => {
+    for (const host of hosts) host.dispose()
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    if (originalPath === undefined) delete process.env.PATH
+    else process.env.PATH = originalPath
+    if (originalRecord === undefined) delete process.env.FAKE_DWS_RECORD
+    else process.env.FAKE_DWS_RECORD = originalRecord
+    if (originalState === undefined) delete process.env.DSH_DINGTALK_STATE_DIR
+    else process.env.DSH_DINGTALK_STATE_DIR = originalState
+    await rm(root, { recursive: true, force: true })
+  })
+
+  const employees = [
+    employee,
+    { ...employee, agentUuid: 'employee-runtime-2', dwsProfile: 'corp-runtime:user-runtime-2' },
+  ]
+  const first = createHost()
+  hosts.push(first)
+  await apply(first.ctx, pluginConfig(path.join(root, 'workspace'), employees))
+  await waitFor(async () => {
+    try {
+      const records = (await readFile(recordFile, 'utf8'))
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line))
+      return first.followups.length === 2 && records.filter((item) => item.operation === 'reply').length === 2
+    } catch {
+      return false
+    }
+  })
+  assert.equal(new Set(first.followups.map((item) => item.sessionId)).size, 2)
+  assert.ok(first.followups.every((item) => item.message.content[0].text === '只应通过 stdin 回复的正文'))
+
+  first.dispose()
+  await new Promise((resolve) => setTimeout(resolve, 50))
+  const beforeRestart = (await readFile(recordFile, 'utf8'))
+    .split('\n')
+    .filter((line) => line.includes('"operation":"reply"')).length
+  const second = createHost()
+  hosts.push(second)
+  await apply(second.ctx, pluginConfig(path.join(root, 'workspace'), employees))
+  await new Promise((resolve) => setTimeout(resolve, 150))
+  const afterRestart = (await readFile(recordFile, 'utf8'))
+    .split('\n')
+    .filter((line) => line.includes('"operation":"reply"')).length
+  assert.equal(second.followups.length, 0)
+  assert.equal(afterRestart, beforeRestart)
+})

--- a/test/digital-employee-runtime.test.mjs
+++ b/test/digital-employee-runtime.test.mjs
@@ -111,7 +111,8 @@ if (operation === 'consume') {
   process.stdin.on('data', (chunk) => { input += chunk })
   process.stdin.on('end', () => {
     const value = input ? JSON.parse(input) : {}
-    process.stdout.write(JSON.stringify({ ok: true, outcome: 'success', data: { openMessageId: operation === 'reply' ? 'outgoing-1' : 'operator-message-1', conversationId: value.conversationId || 'operator-conversation', deliveryStatus: 'delivered', idempotencyKey: value.idempotencyKey }, meta: {} }))
+    const openMessageId = process.env.FAKE_DWS_EMPTY_RECEIPT === '1' ? '' : operation === 'reply' ? 'outgoing-1' : 'operator-message-1'
+    process.stdout.write(JSON.stringify({ ok: true, outcome: 'success', data: { openMessageId, conversationId: value.conversationId || 'operator-conversation', deliveryStatus: 'delivered', idempotencyKey: value.idempotencyKey }, meta: {} }))
   })
 }
 `
@@ -343,7 +344,11 @@ test('fake DWS 验证 ready、半行/坏包隔离、白名单、去重、自回�
   await waitFor(() => accepted.length === 1 && runtime.currentStatus().lastReplyAt)
   await new Promise((resolve) => setTimeout(resolve, 100))
 
-  assert.equal(runtime.currentStatus().state, 'ready')
+  const currentStatus = runtime.currentStatus()
+  assert.equal(currentStatus.state, 'ready')
+  assert.ok(currentStatus.observedAt >= currentStatus.lastEventAt)
+  assert.ok(currentStatus.observedAt >= currentStatus.lastReplyAt)
+  assert.ok(currentStatus.observedAt >= currentStatus.lastAuditAt)
   assert.equal(accepted.length, 1)
   assert.equal(accepted[0].scopeKey, 'employee-runtime-1:allowed-group#allowed-open-id')
   assert.equal(accepted[0].message.text, '只应通过 stdin 回复的正文')
@@ -418,6 +423,53 @@ test('ledger 损坏时隔离目标员工并持久化 doctor 可见的 fail-close
   if (process.platform !== 'win32') {
     assert.equal((await stat(path.join(stateDir, 'runtime.json'))).mode & 0o777, 0o600)
   }
+})
+
+test('DWS 空消息 ID 回执会 fail-closed 且不会污染自回复 ledger', async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-de-empty-receipt-'))
+  const stateDir = path.join(root, 'state')
+  const recordFile = path.join(root, 'invocations.ndjson')
+  const dwsInvocation = await createFakeDws(root)
+  const originalRecord = process.env.FAKE_DWS_RECORD
+  const originalEmptyReceipt = process.env.FAKE_DWS_EMPTY_RECEIPT
+  process.env.FAKE_DWS_RECORD = recordFile
+  process.env.FAKE_DWS_EMPTY_RECEIPT = '1'
+  const runtime = new DwsDigitalEmployeeSource({
+    employee,
+    stateDir,
+    ...dwsInvocation,
+    log: () => {},
+    onMessage: () => {},
+  })
+  t.after(async () => {
+    await runtime.stop()
+    if (originalRecord === undefined) delete process.env.FAKE_DWS_RECORD
+    else process.env.FAKE_DWS_RECORD = originalRecord
+    if (originalEmptyReceipt === undefined) delete process.env.FAKE_DWS_EMPTY_RECEIPT
+    else process.env.FAKE_DWS_EMPTY_RECEIPT = originalEmptyReceipt
+    await rm(root, { recursive: true, force: true })
+  })
+
+  await assert.rejects(
+    runtime.replySink.reply(
+      {
+        schemaVersion: 1,
+        eventId: 'empty-receipt-event',
+        messageId: 'incoming-message',
+        conversationId: 'allowed-group',
+        conversationType: 'group',
+        senderOpenDingTalkId: 'allowed-open-id',
+        senderName: '成员',
+        text: '不应写入 ledger 的回复',
+        createdAt: '1',
+      },
+      'session-1',
+      '回复正文',
+    ),
+    /invalid_reply_result/,
+  )
+  await assert.rejects(readFile(path.join(stateDir, 'ledger.json'), 'utf8'), { code: 'ENOENT' })
+  assert.equal(runtime.currentStatus().failureCode, 'invalid_reply_result')
 })
 
 test('启动失败严格执行 retryable=false/true/unknown 的 0/2/1 重试预算', async (t) => {

--- a/test/digital-employee-runtime.test.mjs
+++ b/test/digital-employee-runtime.test.mjs
@@ -27,6 +27,21 @@ const employee = {
   protocolVersion: 1,
 }
 
+async function writeFakeDwsCommand(root, name, source) {
+  const command = path.join(root, name)
+  if (process.platform !== 'win32') {
+    await writeFile(command, source, { mode: 0o755 })
+    await chmod(command, 0o755)
+    return command
+  }
+
+  const script = path.join(root, `${name}.cjs`)
+  const wrapper = path.join(root, `${name}.cmd`)
+  await writeFile(script, source, 'utf8')
+  await writeFile(wrapper, `@echo off\r\n"${process.execPath}" "%~dp0${name}.cjs" %*\r\n`, 'utf8')
+  return wrapper
+}
+
 test('本地白名单分别覆盖 operator、额外私聊、群白名单和默认拒绝', () => {
   const base = {
     schemaVersion: 1,
@@ -62,7 +77,6 @@ test('本地白名单分别覆盖 operator、额外私聊、群白名单和默�
 })
 
 async function createFakeDws(root) {
-  const command = path.join(root, 'dws')
   const source = `#!/usr/bin/env node
 const fs = require('node:fs')
 const record = process.env.FAKE_DWS_RECORD
@@ -104,13 +118,10 @@ if (operation === 'consume') {
   })
 }
 `
-  await writeFile(command, source, { mode: 0o755 })
-  await chmod(command, 0o755)
-  return command
+  return writeFakeDwsCommand(root, 'dws', source)
 }
 
 async function createRetryFakeDws(root) {
-  const command = path.join(root, 'dws-retry')
   const source = `#!/usr/bin/env node
 const fs = require('node:fs')
 const args = process.argv.slice(2)
@@ -135,13 +146,10 @@ if (args.includes('consume')) {
   process.on('SIGTERM', () => process.exit(0))
 }
 `
-  await writeFile(command, source, { mode: 0o755 })
-  await chmod(command, 0o755)
-  return command
+  return writeFakeDwsCommand(root, 'dws-retry', source)
 }
 
 async function createAuditFailFakeDws(root) {
-  const command = path.join(root, 'dws-audit-fail')
   const source = `#!/usr/bin/env node
 const args = process.argv.slice(2)
 if (args.includes('capabilities')) {
@@ -157,13 +165,10 @@ if (args.includes('consume')) {
   process.on('SIGTERM', () => process.exit(0))
 }
 `
-  await writeFile(command, source, { mode: 0o755 })
-  await chmod(command, 0o755)
-  return command
+  return writeFakeDwsCommand(root, 'dws-audit-fail', source)
 }
 
 async function createSlowExitFakeDws(root) {
-  const command = path.join(root, 'dws-slow-exit')
   const source = `#!/usr/bin/env node
 const fs = require('node:fs')
 const args = process.argv.slice(2)
@@ -198,9 +203,7 @@ if (args.includes('consume')) {
   }
 }
 `
-  await writeFile(command, source, { mode: 0o755 })
-  await chmod(command, 0o755)
-  return command
+  return writeFakeDwsCommand(root, 'dws-slow-exit', source)
 }
 
 function createHost() {
@@ -374,11 +377,13 @@ test('fake DWS 验证 ready、半行/坏包隔离、白名单、去重、自回�
     'json',
   ])
 
-  assert.equal((await stat(stateDir)).mode & 0o777, 0o700)
-  assert.equal((await stat(path.join(stateDir, 'ledger.json'))).mode & 0o777, 0o600)
-  assert.equal((await stat(path.join(stateDir, 'runtime.json'))).mode & 0o777, 0o600)
-  assert.equal((await stat(path.join(stateDir, 'audit'))).mode & 0o777, 0o700)
-  assert.equal((await stat(path.join(stateDir, 'audit', 'employee-runtime-1.jsonl'))).mode & 0o777, 0o600)
+  if (process.platform !== 'win32') {
+    assert.equal((await stat(stateDir)).mode & 0o777, 0o700)
+    assert.equal((await stat(path.join(stateDir, 'ledger.json'))).mode & 0o777, 0o600)
+    assert.equal((await stat(path.join(stateDir, 'runtime.json'))).mode & 0o777, 0o600)
+    assert.equal((await stat(path.join(stateDir, 'audit'))).mode & 0o777, 0o700)
+    assert.equal((await stat(path.join(stateDir, 'audit', 'employee-runtime-1.jsonl'))).mode & 0o777, 0o600)
+  }
   assert.doesNotMatch(await readFile(path.join(stateDir, 'ledger.json'), 'utf8'), /正文/)
   assert.doesNotMatch(await readFile(path.join(stateDir, 'audit', 'employee-runtime-1.jsonl'), 'utf8'), /正文/)
 
@@ -407,7 +412,9 @@ test('ledger 损坏时隔离目标员工并持久化 doctor 可见的 fail-close
   const status = JSON.parse(await readFile(path.join(stateDir, 'runtime.json'), 'utf8'))
   assert.equal(status.state, 'failed')
   assert.equal(status.failureCode, 'ledger_corrupt')
-  assert.equal((await stat(path.join(stateDir, 'runtime.json'))).mode & 0o777, 0o600)
+  if (process.platform !== 'win32') {
+    assert.equal((await stat(path.join(stateDir, 'runtime.json'))).mode & 0o777, 0o600)
+  }
 })
 
 test('启动失败严格执行 retryable=false/true/unknown 的 0/2/1 重试预算', async (t) => {
@@ -576,7 +583,7 @@ test('无机器人时启动两个数字员工，复用 Bridge/Queue/Session 并�
   await writeFile(path.join(root, '.keep'), '')
   await mkdir(binDir, { recursive: true })
   const fake = await createFakeDws(binDir)
-  assert.equal(fake, path.join(binDir, 'dws'))
+  assert.equal(fake, path.join(binDir, process.platform === 'win32' ? 'dws.cmd' : 'dws'))
   const recordFile = path.join(root, 'host-invocations.ndjson')
   const stateDir = path.join(root, 'state')
   const originalPath = process.env.PATH

--- a/test/doctor-report.test.mjs
+++ b/test/doctor-report.test.mjs
@@ -194,6 +194,154 @@ test('联网诊断异常和远端能力原因不会进入机器报告', async (t
   )
 })
 
+test('数字员工诊断按员工输出 Profile、能力、ready、订阅、事件、回复和远程审计且不含正文', async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-de-doctor-'))
+  t.after(() => import('node:fs/promises').then((fs) => fs.rm(root, { recursive: true, force: true })))
+  const dshHome = await createProfile(
+    root,
+    [
+      '- id: dingtalk-channel',
+      '  config:',
+      '    digitalEmployees:',
+      '      - agentUuid: employee-doctor-1',
+      '        enabled: true',
+      '        dwsProfile: corp-doctor:user-doctor',
+      '        operatorOpenDingTalkId: operator-private-id',
+      '        allowedDirectSenders: [direct-private-id]',
+      '        allowedGroups: [group-private-id]',
+      '        sessionScope: chat',
+      '        protocolVersion: 1',
+      '',
+    ].join('\n'),
+  )
+  const stateDir = path.join(root, '.dsh-dingtalk')
+  const runtimeDir = path.join(stateDir, 'digital-employees', 'employee-doctor-1')
+  await mkdir(runtimeDir, { recursive: true, mode: 0o700 })
+  await writeFile(
+    path.join(runtimeDir, 'runtime.json'),
+    JSON.stringify({
+      state: 'ready',
+      observedAt: Date.now(),
+      capabilitiesVerifiedAt: 1,
+      subscriptionTopics: ['user_im_message_receive_o2o_all', 'user_im_message_receive_group_all'],
+      lastEventAt: 2,
+      lastReplyAt: 3,
+      lastAuditAt: 4,
+      forbiddenBody: 'chat-private-body',
+    }),
+    { mode: 0o600 },
+  )
+
+  const report = await collectDoctorReport({ mode: 'offline', dshHome, stateDir })
+
+  assert.deepEqual(report.accounts, [])
+  assert.equal(report.digitalEmployees.length, 1)
+  assert.equal(report.digitalEmployees[0].agentUuid, 'employee-doctor-1')
+  assert.equal(report.digitalEmployees[0].dwsProfile, 'corp-doctor:user-doctor')
+  assert.equal(report.digitalEmployees[0].result, 'pass')
+  assert.deepEqual(
+    report.digitalEmployees[0].checks.map((check) => check.code),
+    [
+      'digital-employee.configured',
+      'digital-employee.whitelist-configured',
+      'digital-employee.capabilities-verified',
+      'digital-employee.ready',
+      'digital-employee.subscription-ready',
+      'digital-employee.event-observed',
+      'digital-employee.reply-observed',
+      'digital-employee.audit-observed',
+    ],
+  )
+  assert.doesNotMatch(
+    JSON.stringify(report),
+    /operator-private-id|direct-private-id|group-private-id|chat-private-body/,
+  )
+})
+
+test('数字员工陈旧状态不能继续报告 ready、能力、订阅或最近链路通过', async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-de-doctor-stale-'))
+  t.after(() => import('node:fs/promises').then((fs) => fs.rm(root, { recursive: true, force: true })))
+  const dshHome = await createProfile(
+    root,
+    [
+      '- id: dingtalk-channel',
+      '  config:',
+      '    digitalEmployees:',
+      '      - agentUuid: employee-stale-1',
+      '        dwsProfile: corp-stale:user-stale',
+      '        operatorOpenDingTalkId: operator-stale',
+      '        protocolVersion: 1',
+      '',
+    ].join('\n'),
+  )
+  const stateDir = path.join(root, '.dsh-dingtalk')
+  const runtimeDir = path.join(stateDir, 'digital-employees', 'employee-stale-1')
+  await mkdir(runtimeDir, { recursive: true })
+  await writeFile(
+    path.join(runtimeDir, 'runtime.json'),
+    JSON.stringify({
+      state: 'ready',
+      observedAt: Date.now() - 31_000,
+      capabilitiesVerifiedAt: Date.now() - 31_000,
+      subscriptionTopics: ['user_im_message_receive_o2o_all', 'user_im_message_receive_group_all'],
+      lastEventAt: Date.now() - 31_000,
+      lastReplyAt: Date.now() - 31_000,
+      lastAuditAt: Date.now() - 31_000,
+    }),
+  )
+
+  const report = await collectDoctorReport({ mode: 'offline', dshHome, stateDir })
+  assert.deepEqual(
+    report.digitalEmployees[0].checks.slice(2).map((check) => check.code),
+    [
+      'digital-employee.capabilities-unverified',
+      'digital-employee.stale',
+      'digital-employee.subscription-unverified',
+      'digital-employee.event-unobserved',
+      'digital-employee.reply-unobserved',
+      'digital-employee.audit-unobserved',
+    ],
+  )
+})
+
+test('数字员工与旧版根级机器人并存时仍诊断默认机器人', async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-de-doctor-legacy-bot-'))
+  t.after(() => import('node:fs/promises').then((fs) => fs.rm(root, { recursive: true, force: true })))
+  const dshHome = await createProfile(
+    root,
+    [
+      '- id: dingtalk-channel',
+      '  config:',
+      '    ownerStaffId: legacy-owner',
+      '    digitalEmployees:',
+      '      - agentUuid: employee-with-bot',
+      '        dwsProfile: corp-with-bot:user-with-bot',
+      '        operatorOpenDingTalkId: operator-with-bot',
+      '        protocolVersion: 1',
+      '',
+    ].join('\n'),
+  )
+  await writeFile(
+    path.join(dshHome, '.credentials.yaml'),
+    'version: 1\nrefs:\n  DINGTALK_CLIENT_ID: legacy-client\n  DINGTALK_CLIENT_SECRET: legacy-secret\n',
+    { mode: 0o600 },
+  )
+
+  const report = await collectDoctorReport({
+    mode: 'offline',
+    dshHome,
+    stateDir: path.join(root, '.dsh-dingtalk'),
+  })
+  assert.deepEqual(
+    report.accounts.map((account) => account.id),
+    ['default'],
+  )
+  assert.deepEqual(
+    report.digitalEmployees.map((item) => item.agentUuid),
+    ['employee-with-bot'],
+  )
+})
+
 test('多账号报告逐账号汇总，单个告警决定整体 warning', async (t) => {
   const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-doctor-multi-'))
   t.after(() => import('node:fs/promises').then((fs) => fs.rm(root, { recursive: true, force: true })))

--- a/test/doctor-report.test.mjs
+++ b/test/doctor-report.test.mjs
@@ -194,7 +194,7 @@ test('联网诊断异常和远端能力原因不会进入机器报告', async (t
   )
 })
 
-test('数字员工诊断按员工输出 Profile、能力、ready、订阅、事件、回复和远程审计且不含正文', async (t) => {
+test('数字员工诊断按员工输出 Profile、能力、ready、订阅、事件、回复和本地审计且不含正文', async (t) => {
   const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-de-doctor-'))
   t.after(() => import('node:fs/promises').then((fs) => fs.rm(root, { recursive: true, force: true })))
   const dshHome = await createProfile(

--- a/test/questions.test.mjs
+++ b/test/questions.test.mjs
@@ -24,8 +24,8 @@ function harness(timeoutMs = 1_000, delivered = true, interactionCards, approval
   let definition
   const manager = new QuestionManager({
     outbound: {
-      async sendMarkdown(sessionWebhook, title, text) {
-        sent.push({ sessionWebhook, title, text })
+      async sendMarkdown(message, title, text) {
+        sent.push({ sessionWebhook: message.sessionWebhook, title, text })
         return delivered
       },
     },
@@ -397,8 +397,8 @@ test('钉钉审批优先于先注册的 Web 全局审批处理器', async () => 
   const sent = []
   const manager = new QuestionManager({
     outbound: {
-      async sendMarkdown(sessionWebhook, title, text) {
-        sent.push({ sessionWebhook, title, text })
+      async sendMarkdown(message, title, text) {
+        sent.push({ sessionWebhook: message.sessionWebhook, title, text })
         return true
       },
     },
@@ -632,8 +632,8 @@ test('复用已加载的 Agent 时补装 scoped ask_user_question，且重复调
   let definition
   const manager = new QuestionManager({
     outbound: {
-      async sendMarkdown(sessionWebhook, title, text) {
-        sent.push({ sessionWebhook, title, text })
+      async sendMarkdown(message, title, text) {
+        sent.push({ sessionWebhook: message.sessionWebhook, title, text })
         return true
       },
     },

--- a/test/setup-flow.test.mjs
+++ b/test/setup-flow.test.mjs
@@ -11,6 +11,8 @@ import { credentialLayoutForDshVersion, runGuidedSetup } from '../lib/setup.js'
 import {
   saveDingTalkAccountCredentials,
   saveDingTalkCredentials,
+  registerDigitalEmployee,
+  loadWebProfileConfig,
   upsertWebProfileAccount,
   updateWebProfileConfig,
 } from '../lib/setup-state.js'
@@ -774,4 +776,83 @@ test('setup 自动升级不兼容的旧 pnpm 后再安装插件', async (t) => {
   const upgradeIndex = runner.calls.findIndex((call) => call.join(' ') === 'npm install --global pnpm@latest')
   const pluginIndex = runner.calls.findIndex((call) => call[0] === 'dsh' && call[1] === 'plugin')
   assert.ok(upgradeIndex >= 0 && pluginIndex > upgradeIndex)
+})
+
+test('仅配置数字员工时 setup 不要求机器人凭据并可管理 operator 与白名单', async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-de-setup-'))
+  t.after(() => import('node:fs/promises').then((fs) => fs.rm(root, { recursive: true, force: true })))
+  const dshHome = path.join(root, '.dsh')
+  await registerDigitalEmployee(dshHome, {
+    schemaVersion: 1,
+    agentUuid: 'employee-setup-1',
+    name: '运营助手',
+    dwsProfile: 'corp-setup:user-setup',
+    operatorOpenDingTalkId: 'operator-open-id',
+    protocolVersion: 1,
+  })
+  const ui = new FakeUi({
+    setupAction: 'digital-employees',
+    confirmDigitalEmployeeOperator: true,
+    digitalEmployeeDirectAllowlist: 'direct-a, direct-b',
+    digitalEmployeeGroupAllowlist: 'group-a，group-b',
+    digitalEmployeeSessionScope: 'chat-sender',
+    startWeb: false,
+  })
+
+  const result = await runGuidedSetup({
+    ui,
+    runner: new FakeRunner(),
+    dshHome,
+    stateDir: path.join(root, '.dsh-dingtalk'),
+    installSpec: '@dingtalk-real-ai/dsh-dingtalk@0.5.0',
+  })
+
+  assert.equal(result.code, 0)
+  assert.equal(ui.prompted.includes('clientId'), false)
+  assert.deepEqual((await loadWebProfileConfig(dshHome)).digitalEmployees[0], {
+    agentUuid: 'employee-setup-1',
+    name: '运营助手',
+    enabled: true,
+    dwsProfile: 'corp-setup:user-setup',
+    operatorOpenDingTalkId: 'operator-open-id',
+    allowedDirectSenders: ['direct-a', 'direct-b'],
+    allowedGroups: ['group-a', 'group-b'],
+    sessionScope: 'chat-sender',
+    protocolVersion: 1,
+  })
+  assert.doesNotMatch(ui.messages.join('\n'), /\/bind/)
+})
+
+test('setup 只能确认 connect 写入的 operator，拒绝后不允许本地改写', async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-dingtalk-de-operator-'))
+  t.after(() => import('node:fs/promises').then((fs) => fs.rm(root, { recursive: true, force: true })))
+  const dshHome = path.join(root, '.dsh')
+  await registerDigitalEmployee(dshHome, {
+    schemaVersion: 1,
+    agentUuid: 'employee-operator-1',
+    name: '运营助手',
+    dwsProfile: 'corp-operator:user-operator',
+    operatorOpenDingTalkId: 'operator-from-connect',
+    protocolVersion: 1,
+  })
+  const ui = new FakeUi({
+    setupAction: 'digital-employees',
+    confirmDigitalEmployeeOperator: false,
+    digitalEmployeeOperator: 'local-forged-operator',
+  })
+
+  await assert.rejects(
+    runGuidedSetup({
+      ui,
+      runner: new FakeRunner(),
+      dshHome,
+      stateDir: path.join(root, '.dsh-dingtalk'),
+      installSpec: '@dingtalk-real-ai/dsh-dingtalk@0.5.0',
+    }),
+    /operator_confirmation_required/,
+  )
+  assert.equal(
+    (await loadWebProfileConfig(dshHome)).digitalEmployees[0].operatorOpenDingTalkId,
+    'operator-from-connect',
+  )
 })


### PR DESCRIPTION
## 目标

在现有数字员工 Channel 实现（`2c5c18b`）上，对齐真实 DWS 机器协议并补齐本地 fail-closed 审计。

## 主要改动

- ready 行接受 `event_count` / `bus_pid` 后缀
- 直接解析 `event consume --flatten` 的 snake_case NDJSON
- reply/operator-private/capabilities 改用 `dingtalk-tag channel ... --format json`
- 严格校验 DWS envelope，并只读取 `data`
- 新增员工级本地 JSONL 审计：目录 0700、文件 0600、跨进程锁、fsync、无正文
- 本地审计不可写时 fail-closed，不接收新 Agent 任务
- fake DWS、doctor 和文档同步真实协议

## 验证

- `pnpm run ci`
  - secret scan ✅
  - Prettier ✅
  - TypeScript typecheck ✅
  - 196 tests ✅
  - NPM tarball smoke ✅（223 files）

## 边界

- 只注册/运行数字员工 Channel，不保存 DWS 凭据
- 不实现远程 audit 强依赖
- 不声明 exactly-once；业务 ack/replay/cursor 仍是后续能力
- DWS `connect` 只返回 `restartRequired`，重启由用户或宿主负责